### PR TITLE
feat(ect): bootstrap OAuth + settings cache + webhook registration + …

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gradle
+/build
+out
+.idea
+.vscode
+*.iml
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Base semelhante ao mentoring (GraalVM + Java 17)
+FROM ghcr.io/graalvm/graalvm-ce:ol7-java17-21.3.0
+
+# Pasta padrão do projeto
+WORKDIR /his/sespct/backend
+
+# Pastas úteis (logs/dados)
+RUN mkdir -p /his/sespct/backend/log /his/sespct/backend/data
+
+# Volumes para logs e (se precisares) dados temporários
+VOLUME ["/his/sespct/backend/log", "/his/sespct/backend/data"]
+
+# Opções JVM e ambiente Micronaut (podem ser sobrepostas no 'docker run')
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
+ENV MICRONAUT_ENVIRONMENTS=production
+
+# Copia o fat JAR (gera antes com: ./gradlew shadowJar)
+# Mantém o nome estável dentro da imagem
+COPY build/libs/*-all.jar /his/sespct/backend/sespct-api-all.jar
+
+# Porta da app (conforme application.yml)
+EXPOSE 8383
+
+# Arranque
+CMD ["sh", "-c", "java $JAVA_OPTS -jar /his/sespct/backend/sespct-api-all.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation("io.swagger.core.v3:swagger-jaxrs2:2.1.11")
     implementation("io.swagger.core.v3:swagger-core:2.1.11")
     implementation("io.micronaut.serde:micronaut-serde-jackson")
+    implementation("io.micronaut.cache:micronaut-cache-caffeine")
 
 
     implementation("io.micronaut.security:micronaut-security-jwt")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.8"
+
+services:
+  backend:
+    image: sespct-api:latest
+    container_name: sespct-api
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8383:8383"
+    networks:
+      - sespct-network
+    volumes:
+      - /his/sespct/backend/log:/his/sespct/backend/log
+      - /his/sespct/backend/data:/his/sespct/backend/data
+    environment:
+      MICRONAUT_ENVIRONMENTS: ${MICRONAUT_ENVIRONMENTS:-production}
+      # DB externo (servidor físico)
+      SESPCT_DB_HOST: ${SESPCT_DB_HOST}
+      SESPCT_DB_PORT: ${SESPCT_DB_PORT:-3306}
+      SESPCT_DB_USERNAME: ${SESPCT_DB_USERNAME}
+      SESPCT_DB_PASSWORD: ${SESPCT_DB_PASSWORD}
+      # JWT
+      JWT_GENERATOR_SIGNATURE_SECRET: ${JWT_GENERATOR_SIGNATURE_SECRET}
+    restart: unless-stopped
+
+networks:
+  sespct-network:

--- a/src/main/java/mz/org/csaude/sespcet/api/base/BaseEntity.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/base/BaseEntity.java
@@ -18,11 +18,10 @@ import java.util.Objects;
 import java.util.UUID;
 
 @Data
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @MappedSuperclass
-@Introspected // Enables Micronaut's reflection-free serialization/deserialization
+@Introspected
 @Serdeable.Deserializable
 public abstract class BaseEntity implements RestAPIResponse, Serializable, Comparable<BaseEntity> {
 

--- a/src/main/java/mz/org/csaude/sespcet/api/bootstrap/CtBootstrap.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/bootstrap/CtBootstrap.java
@@ -1,0 +1,289 @@
+package mz.org.csaude.sespcet.api.bootstrap;
+
+import io.micronaut.context.annotation.Value;
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.context.event.StartupEvent;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import mz.org.csaude.sespcet.api.crypto.CtCompactCrypto;
+import mz.org.csaude.sespcet.api.oauth.OAuthService;
+import mz.org.csaude.sespcet.api.service.EctWebhookService;
+import mz.org.csaude.sespcet.api.service.SettingService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static mz.org.csaude.sespcet.api.config.SettingKeys.*;
+
+@Singleton
+public class CtBootstrap implements ApplicationEventListener<StartupEvent> {
+
+    private static final Logger log = LoggerFactory.getLogger(CtBootstrap.class);
+    private final AtomicBoolean ran = new AtomicBoolean(false); // hard guard against double fire
+
+    private final SettingService settings;
+    private final CtCompactCrypto crypto;
+    private final OAuthService oauth;
+    private final EctWebhookService webhookService;
+
+    @Value("${micronaut.server.port:8383}")
+    int serverPort;
+
+    @Value("${micronaut.server.context-path:/api}")
+    String contextPath;
+
+    @Value("${micronaut.server.ssl.enabled:false}")
+    boolean sslEnabled;
+
+    @Inject @Client("/") HttpClient http;
+
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "ct-bootstrap-scheduler");
+        t.setDaemon(true);
+        return t;
+    });
+
+
+    public CtBootstrap(SettingService settings, CtCompactCrypto crypto, OAuthService oauth, EctWebhookService webhookService) {
+        this.settings = settings;
+        this.crypto = crypto;
+        this.oauth = oauth;
+        this.webhookService = webhookService;
+    }
+
+    @Override
+    public void onApplicationEvent(StartupEvent event) {
+        if (!ran.compareAndSet(false, true)) {
+            return; // already executed
+        }
+        log.info("CtBootstrap: start");
+
+        primeBaseAndDerivedUrls();
+        ensureClientId();
+        ensureKeyPairForApi();
+        ensureRegistration();
+        log.info("CtBootstrap: done");
+
+        // Try to obtain a token shortly after startup; retry a few times without killing the app.
+        scheduleTokenFetchWithRetry();
+    }
+
+    private void scheduleTokenFetchWithRetry() {
+        final int maxAttempts = 5;
+        final long delaySec = 5;
+
+        scheduler.scheduleWithFixedDelay(new Runnable() {
+            int attempt = 0;
+            @Override public void run() {
+                attempt++;
+                try {
+                    String token = oauth.getToken();
+                    if (token != null && !token.isBlank()) {
+                        log.info("CtBootstrap: token obtained on attempt {}", attempt);
+                        try {
+                            webhookService.ensureRegistered();
+                            log.info("CtBootstrap: webhook verificado/registado");
+                        } catch (Exception ex) {
+                            log.warn("CtBootstrap: falha ao registar webhook: {}", ex.toString());
+                        }
+                        scheduler.shutdown();
+                    } else {
+                        throw new IllegalStateException("Empty token");
+                    }
+                } catch (Exception e) {
+                    if (attempt >= maxAttempts) {
+                        log.warn("CtBootstrap: failed to obtain token after {} attempts – will continue without prefetch. Cause: {}",
+                                attempt, e.toString());
+                        scheduler.shutdown();
+                    } else {
+                        log.warn("CtBootstrap: token attempt {}/{} failed ({}). Retrying in {}s…",
+                                attempt, maxAttempts, e.toString(), delaySec);
+                    }
+                }
+            }
+        }, delaySec, delaySec, TimeUnit.SECONDS);
+    }
+
+    /* -------------------- steps -------------------- */
+    private void primeBaseAndDerivedUrls() {
+        // ---------- CT base & derivados ----------
+        String base = settings.get(CT_BASE_URL, null);
+        if (isBlank(base)) {
+            base = "https://api.comitetarvmisau.co.mz";
+            settings.upsert(CT_BASE_URL, base, "STRING", "Base URL do eCT", true, "system");
+        }
+        if (isBlank(settings.get(CT_REGISTER_URL, null))) {
+            settings.upsert(CT_REGISTER_URL, join(base, "/oauth2/clients"),
+                    "STRING", "URL de registo de clientes no eCT", true, "system");
+        }
+        if (isBlank(settings.get(CT_OAUTH_TOKEN_URL, null))) {
+            settings.upsert(CT_OAUTH_TOKEN_URL, join(base, "/oauth2/token"),
+                    "STRING", "URL de token OAuth no eCT", true, "system");
+        }
+
+        // ---------- SESPCT-API base ----------
+        String apiBase = settings.get(SESPCT_API_BASE_URL, null);
+        if (isBlank(apiBase)) {
+            String scheme = sslEnabled ? "https" : "http";
+            // host padrão "localhost"; se estiver atrás de proxy, podes definir por env SESPCT_API_BASE_URL
+            apiBase = scheme + "://localhost:" + serverPort + normalizePath(contextPath);
+            settings.upsert(SESPCT_API_BASE_URL, apiBase, "STRING",
+                    "Base URL desta API (SESPCT-API)", true, "system");
+        }
+
+        // ---------- CT webhook URL (derivado da base da tua API) ----------
+        if (isBlank(settings.get(CT_WEBHOOK_URL, null))) {
+            String webhookUrl = join(apiBase, "/public/webhook/e-ft");
+            settings.upsert(CT_WEBHOOK_URL, webhookUrl, "STRING",
+                    "URL pública para receção de webhooks do eCT", true, "system");
+        }
+    }
+
+    private void ensureClientId() {
+        String cid = settings.get(CT_OAUTH_CLIENT_ID, null);
+        if (isBlank(cid)) {
+            String gen = "sespct_" + randomHex(8) + "_" + new SimpleDateFormat("yyyyMMdd").format(new Date());
+            settings.upsert(CT_OAUTH_CLIENT_ID, gen, "STRING", "Client ID do OAuth no eCT", true, "system");
+        }
+        if (isBlank(settings.get(CT_KEYS_CLIENT_KEY_ID, null))) {
+            settings.upsert(CT_KEYS_CLIENT_KEY_ID, "sespct-api-key-1", "STRING",
+                    "Identificador lógico para rotação de chaves", true, "system");
+        }
+    }
+
+    private void ensureKeyPairForApi() {
+        String pub = settings.get(CT_KEYS_SESPCTAPI_PUBLIC_PEM, null);
+        String prv = settings.get(CT_KEYS_SESPCTAPI_PRIVATE_PEM, null);
+        if (isBlank(pub) || isBlank(prv)) {
+            try {
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+                kpg.initialize(2048, new SecureRandom());
+                KeyPair kp = kpg.generateKeyPair();
+
+                String pubPem = toPem("PUBLIC KEY", kp.getPublic().getEncoded());
+                String prvPem = toPem("PRIVATE KEY", kp.getPrivate().getEncoded());
+
+                settings.upsert(CT_KEYS_SESPCTAPI_PUBLIC_PEM, pubPem, "TEXT",
+                        "Chave pública SESPCT API (PEM)", true, "system");
+                settings.upsert(CT_KEYS_SESPCTAPI_PRIVATE_PEM, prvPem, "TEXT",
+                        "Chave privada SESPCT API (PEM)", true, "system");
+            } catch (Exception e) {
+                throw new RuntimeException("Falha ao gerar par de chaves RSA (SESPCT API)", e);
+            }
+        }
+    }
+
+    private void ensureRegistration() {
+        String clientId  = settings.get(CT_OAUTH_CLIENT_ID, null);
+        String encSecret = settings.get(CT_OAUTH_CLIENT_SECRET, null);
+
+        if (!isBlank(encSecret)) return; // already registered
+
+        String plainSecret = "secret-" + UUID.randomUUID();
+
+        PlainRegisterResult rr = plainRegister(
+                clientId,
+                plainSecret,
+                settings.get(CT_KEYS_SESPCTAPI_PUBLIC_PEM, "")
+        );
+
+        if (!isBlank(rr.serverPublicKey)) {
+            settings.upsert(CT_KEYS_CT_PUBLIC_PEM, rr.serverPublicKey, "TEXT",
+                    "Chave pública do servidor eCT (PEM)", true, "system");
+        }
+        if (!isBlank(rr.clientId) && !rr.clientId.equals(clientId)) {
+            settings.upsert(CT_OAUTH_CLIENT_ID, rr.clientId, "STRING",
+                    "Client ID do OAuth no eCT", true, "system");
+        }
+
+        String encrypted = crypto.encryptForGP(plainSecret);
+        settings.upsert(CT_OAUTH_CLIENT_SECRET, encrypted, "SECRET",
+                "Client secret do OAuth no eCT (cifrado)", true, "system");
+    }
+
+    /* -------------------- helpers -------------------- */
+
+    private PlainRegisterResult plainRegister(String clientId, String clientSecret, String publicPem) {
+        String registerUrl = settings.get(CT_REGISTER_URL, null);
+        if (isBlank(registerUrl)) {
+            throw new IllegalStateException("CT register URL não definida");
+        }
+        final URI uri;
+        try {
+            uri = new URI(registerUrl);  // validate untrusted input
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("CT register URL inválida: " + registerUrl, e);
+        }
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("clientId", clientId);
+        body.put("clientSecret", clientSecret);
+        body.put("publicKey", publicPem);
+        body.put("keyExpirationDuration", 365);
+        body.put("initialKeyVersion", "1");
+        body.put("scopes", "read,write");
+
+        HttpRequest<Map<String, Object>> req = HttpRequest.POST(uri, body)
+                .contentType(MediaType.APPLICATION_JSON_TYPE)
+                .header("scopes", "admin");
+
+        Map<String, Object> m;
+        try {
+            m = http.toBlocking().retrieve(req, io.micronaut.core.type.Argument.mapOf(String.class, Object.class));
+        } catch (io.micronaut.http.client.exceptions.HttpClientResponseException e) {
+            throw new IllegalStateException("Falha no registo de cliente no eCT: " + e.getStatus(), e);
+        }
+
+        PlainRegisterResult out = new PlainRegisterResult();
+        out.clientId = m.getOrDefault("clientId", clientId).toString();
+        out.serverPublicKey = (m.get("serverPublicKey") != null) ? m.get("serverPublicKey").toString() : null;
+        return out;
+    }
+
+    private static class PlainRegisterResult {
+        String clientId;
+        String serverPublicKey;
+    }
+
+    private static boolean isBlank(String s) { return s == null || s.trim().isEmpty(); }
+
+    private static String randomHex(int n) {
+        byte[] b = new byte[n / 2];
+        new SecureRandom().nextBytes(b);
+        StringBuilder sb = new StringBuilder();
+        for (byte x : b) sb.append(String.format("%02x", x));
+        return sb.toString();
+    }
+
+    private static String toPem(String type, byte[] der) {
+        String b64 = Base64.getMimeEncoder(64, "\n".getBytes()).encodeToString(der);
+        return "-----BEGIN " + type + "-----\n" + b64 + "\n-----END " + type + "-----";
+    }
+
+    private static String normalizePath(String p) {
+        if (p == null || p.isBlank()) return "";
+        // garantir que começa com "/" e não termina com "/"
+        String s = p.startsWith("/") ? p : "/" + p;
+        return s.equals("/") ? "" : s.replaceAll("/+$", "");
+    }
+    private static String join(String base, String suffix) {
+        if (base == null) base = "";
+        if (suffix == null) suffix = "";
+        return base.replaceAll("/+$", "") + (suffix.startsWith("/") ? suffix : "/" + suffix);
+    }
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/bootstrap/CtBootstrap.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/bootstrap/CtBootstrap.java
@@ -148,8 +148,8 @@ public class CtBootstrap implements ApplicationEventListener<StartupEvent> {
 
         // ---------- CT webhook URL (derivado da base da tua API) ----------
         if (isBlank(settings.get(CT_WEBHOOK_URL, null))) {
-            String webhookUrl = join(apiBase, "/public/webhook/e-ft");
-            settings.upsert(CT_WEBHOOK_URL, webhookUrl, "STRING",
+            String webhookUrl = join(apiBase, "/public/webhook/ect");
+            settings.upsert(CT_WEBHOOK_URL, "https://viewing-polish-diagnostic-supplier.trycloudflare.com/api/public/webhook/ect", "STRING",
                     "URL pública para receção de webhooks do eCT", true, "system");
         }
     }

--- a/src/main/java/mz/org/csaude/sespcet/api/config/SettingKeys.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/config/SettingKeys.java
@@ -1,0 +1,28 @@
+package mz.org.csaude.sespcet.api.config;
+
+public final class SettingKeys {
+    private SettingKeys() {}
+
+    // CT / eCT integration
+    public static final String CT_BASE_URL                      = "sesp.ct.baseUrl";
+    public static final String CT_OAUTH_TOKEN_URL               = "sesp.ct.oauth.tokenUrl";
+    public static final String CT_OAUTH_CLIENT_ID               = "sesp.ct.oauth.clientId";
+    public static final String CT_OAUTH_CLIENT_SECRET           = "sesp.ct.oauth.clientSecret";
+
+    public static final String CT_KEYS_CT_PUBLIC_PEM            = "sesp.ct.keys.ctPublicPem";
+    public static final String CT_KEYS_SESPCTAPI_PUBLIC_PEM     = "sesp.ct.keys.sespctApiPublicPem";
+    public static final String CT_KEYS_SESPCTAPI_PRIVATE_PEM    = "sesp.ct.keys.sespctApiPrivatePem";
+    public static final String CT_KEYS_CLIENT_KEY_ID            = "sesp.ct.keys.clientKeyId";
+
+    public static final String CT_WEBHOOK_URL                   = "sesp.ct.webhook.url";
+    public static final String CT_REGISTER_URL                  = "sesp.ct.register.url";
+    public static final String CT_DEFAULT_FACILITY              = "sesp.ct.facilityCode";
+    public static final String CT_SINCE_ISO                     = "sesp.ct.since";
+
+    /** Master key (AES-256, Base64) usada para cifrar valores em settings */
+    public static final String CT_KMS_MASTER_KEY_B64            = "sesp.ct.kms.masterKeyB64";
+
+    public static final String CT_WEBHOOK_REGISTERED    = "sesp.ct.webhook.registered"; // boolean "true"/"false"
+    public static final String CT_WEBHOOK_EVENTS        = "sesp.ct.webhook.events";     // CSV, ex: PEDIDO_REPLIED,PEDIDO_UPDATED,RESPOSTA_UPDATED
+    public static final String SESPCT_API_BASE_URL      = "sespct.api.baseUrl";
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/controller/WebhookController.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/controller/WebhookController.java
@@ -2,19 +2,21 @@ package mz.org.csaude.sespcet.api.controller;
 
 import io.micronaut.http.*;
 import io.micronaut.http.annotation.*;
-import jakarta.inject.Singleton;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
 import lombok.extern.slf4j.Slf4j;
 import mz.org.csaude.sespcet.api.crypto.CtCompactCrypto;
-import mz.org.csaude.sespcet.api.dto.ClientDataDTO;
+import mz.org.csaude.sespcet.api.dto.EncryptedRequestDTO;
 import mz.org.csaude.sespcet.api.service.SettingService;
 
+import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.util.Map;
 
 import static mz.org.csaude.sespcet.api.config.SettingKeys.*;
 
-@Controller("/api/public/webhook/e-ft")
+@Secured(SecurityRule.IS_ANONYMOUS)
+@Controller("/public/webhook/ect")
 @Slf4j
 public class WebhookController {
 
@@ -27,31 +29,49 @@ public class WebhookController {
     }
 
     @Post
-    public HttpResponse<?> receive(@Body ClientDataDTO dto) {
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.TEXT_PLAIN)
+    public HttpResponse<?> receive(@Body EncryptedRequestDTO dto) {
         try {
+            if (dto == null || dto.data() == null || dto.signature() == null) {
+                return HttpResponse.badRequest("Missing data/signature");
+            }
+
+            // logging para diagnóstico
+            log.info("Webhook arrived: dataB64Len={}, sigLen={}, sigHead='{}'",
+                    dto.data().length(),
+                    dto.signature().length(),
+                    dto.signature().length() >= 16 ? dto.signature().substring(0, 16) : dto.signature());
+
             String ctPubPem  = settings.get(CT_KEYS_CT_PUBLIC_PEM, null);
             String apiPrvPem = settings.get(CT_KEYS_SESPCTAPI_PRIVATE_PEM, null);
-            if (ctPubPem == null || apiPrvPem == null) return HttpResponse.status(HttpStatus.PRECONDITION_FAILED);
+            if (ctPubPem == null || apiPrvPem == null) {
+                return HttpResponse.status(HttpStatus.PRECONDITION_FAILED, "Missing crypto keys");
+            }
 
             PublicKey  ctPublic   = crypto.readPublicKeyPem(ctPubPem);
             PrivateKey apiPrivate = crypto.readPrivateKeyPem(apiPrvPem);
 
-            // 1) verificar assinatura do servidor (sobre a STRING Base64)
-            boolean ok = crypto.verifySignatureBase64(dto.data(), dto.signature(), ctPublic);
-            if (!ok) return HttpResponse.unauthorized();
+            // 1) verificar assinatura do CT (assina a STRING Base64 de data)
+            boolean ok = crypto.verifySignatureOverString(dto.data(), dto.signature(), ctPublic);
+            if (!ok) {
+                log.warn("Webhook signature verification failed");
+                return HttpResponse.unauthorized();
+            }
 
-            // 2) desencriptar
+            // 2) desencriptar envelope compacto
             byte[] clear = crypto.decryptCompact(dto.data(), apiPrivate);
             String json = new String(clear, java.nio.charset.StandardCharsets.UTF_8);
 
-            // 3) processar evento (exemplo: logar ou mapear p/ service)
-            log.info("Webhook: {}", json);
-            // TODO: chamar serviço de domínio que trate o evento
+            // 3) processar evento (por agora, apenas log)
+            log.info("Webhook clear payload: {}", json);
+            // TODO: encaminhar para o serviço de domínio
 
-            return HttpResponse.ok();
+            return HttpResponse.ok("ok");
         } catch (Exception e) {
-            log.warn("Erro a processar webhook: {}", e.toString());
+            log.warn("Erro a processar webhook", e);
             return HttpResponse.serverError();
         }
     }
+
 }

--- a/src/main/java/mz/org/csaude/sespcet/api/controller/WebhookController.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/controller/WebhookController.java
@@ -1,0 +1,57 @@
+package mz.org.csaude.sespcet.api.controller;
+
+import io.micronaut.http.*;
+import io.micronaut.http.annotation.*;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import mz.org.csaude.sespcet.api.crypto.CtCompactCrypto;
+import mz.org.csaude.sespcet.api.dto.ClientDataDTO;
+import mz.org.csaude.sespcet.api.service.SettingService;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Map;
+
+import static mz.org.csaude.sespcet.api.config.SettingKeys.*;
+
+@Controller("/api/public/webhook/e-ft")
+@Slf4j
+public class WebhookController {
+
+    private final SettingService settings;
+    private final CtCompactCrypto crypto;
+
+    public WebhookController(SettingService settings, CtCompactCrypto crypto) {
+        this.settings = settings;
+        this.crypto = crypto;
+    }
+
+    @Post
+    public HttpResponse<?> receive(@Body ClientDataDTO dto) {
+        try {
+            String ctPubPem  = settings.get(CT_KEYS_CT_PUBLIC_PEM, null);
+            String apiPrvPem = settings.get(CT_KEYS_SESPCTAPI_PRIVATE_PEM, null);
+            if (ctPubPem == null || apiPrvPem == null) return HttpResponse.status(HttpStatus.PRECONDITION_FAILED);
+
+            PublicKey  ctPublic   = crypto.readPublicKeyPem(ctPubPem);
+            PrivateKey apiPrivate = crypto.readPrivateKeyPem(apiPrvPem);
+
+            // 1) verificar assinatura do servidor (sobre a STRING Base64)
+            boolean ok = crypto.verifySignatureBase64(dto.data(), dto.signature(), ctPublic);
+            if (!ok) return HttpResponse.unauthorized();
+
+            // 2) desencriptar
+            byte[] clear = crypto.decryptCompact(dto.data(), apiPrivate);
+            String json = new String(clear, java.nio.charset.StandardCharsets.UTF_8);
+
+            // 3) processar evento (exemplo: logar ou mapear p/ service)
+            log.info("Webhook: {}", json);
+            // TODO: chamar serviço de domínio que trate o evento
+
+            return HttpResponse.ok();
+        } catch (Exception e) {
+            log.warn("Erro a processar webhook: {}", e.toString());
+            return HttpResponse.serverError();
+        }
+    }
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/crypto/CtCompactCrypto.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/crypto/CtCompactCrypto.java
@@ -1,0 +1,232 @@
+// src/main/java/mz/org/csaude/sespcet/api/crypto/CtCompactCrypto.java
+package mz.org.csaude.sespcet.api.crypto;
+
+import io.micronaut.core.annotation.NonNull;
+import jakarta.inject.Singleton;
+import mz.org.csaude.sespcet.api.service.SettingService;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.*;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Optional;
+
+import static mz.org.csaude.sespcet.api.config.SettingKeys.CT_KMS_MASTER_KEY_B64;
+
+@Singleton
+public class CtCompactCrypto {
+
+    private static final OAEPParameterSpec OAEP_SHA256_SHA256 =
+            new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+
+    private static final int GCM_TAG_BITS = 128;   // 16 bytes tag
+    private static final int GCM_IV_BYTES = 12;    // 12 bytes IV (nonce)
+    private static final int AES_BITS = 256;       // requer JDK 17 (ok)
+
+    private final SettingService settings;
+
+    public CtCompactCrypto(SettingService settings) {
+        this.settings = settings;
+    }
+
+    /* ===================== PEM utils ===================== */
+
+    public PrivateKey readPrivateKeyPem(@NonNull String pem) throws Exception {
+        if (pem.contains("BEGIN RSA PRIVATE KEY")) {
+            throw new IllegalArgumentException(
+                    "PKCS#1 detectado. Converta para PKCS#8: openssl pkcs8 -topk8 -in key.pem -out key_pkcs8.pem -nocrypt");
+        }
+        String b64 = pem.replaceAll("-----BEGIN [A-Z0-9 ]+-----", "")
+                .replaceAll("-----END [A-Z0-9 ]+-----", "")
+                .replaceAll("(?m)^Proc-Type:.*\\R?", "")
+                .replaceAll("(?m)^DEK-Info:.*\\R?", "")
+                .replaceAll("[^A-Za-z0-9+/=]", "");
+        byte[] der = Base64.getDecoder().decode(b64);
+        return KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(der));
+    }
+
+    public PublicKey readPublicKeyPem(@NonNull String pem) throws Exception {
+        String b64 = pem.replaceAll("-----BEGIN [A-Z0-9 ]+-----", "")
+                .replaceAll("-----END [A-Z0-9 ]+-----", "")
+                .replaceAll("[^A-Za-z0-9+/=]", "");
+        byte[] der = Base64.getDecoder().decode(b64);
+        return KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(der));
+    }
+
+    /* ===================== CT crypto compat ===================== */
+
+    /** Verifica assinatura CT feita sobre a **string base64** (não sobre os bytes decodificados). */
+    public boolean verifySignatureBase64(String dataB64, String signatureB64, PublicKey ctPublic) throws Exception {
+        byte[] sig = Base64.getDecoder().decode(signatureB64);
+        Signature s = Signature.getInstance("SHA256withRSA");
+        s.initVerify(ctPublic);
+        s.update(dataB64.getBytes(StandardCharsets.UTF_8));
+        return s.verify(sig);
+    }
+
+    /** Desencripta envelope compacto: RSA(wrappedKey) || IV(12) || AES-GCM(ciphertext+tag). */
+    public byte[] decryptCompact(String dataB64, PrivateKey clientPrivate) throws Exception {
+        byte[] blob = Base64.getDecoder().decode(dataB64);
+
+        int rsaLen = (((RSAPrivateKey) clientPrivate).getModulus().bitLength() + 7) / 8; // 2048 → 256
+        if (blob.length < rsaLen + GCM_IV_BYTES + 16) {
+            throw new IllegalArgumentException("Blob demasiado pequeno para rsaLen=" + rsaLen + " (len=" + blob.length + ")");
+        }
+
+        byte[] wrapped = slice(blob, 0, rsaLen);
+        byte[] iv = slice(blob, rsaLen, rsaLen + GCM_IV_BYTES);
+        byte[] ctTag = slice(blob, rsaLen + GCM_IV_BYTES, blob.length);
+
+        Cipher rsa = Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding");
+        rsa.init(Cipher.DECRYPT_MODE, clientPrivate, OAEP_SHA256_SHA256);
+        byte[] aes = rsa.doFinal(wrapped);
+
+        Cipher gcm = Cipher.getInstance("AES/GCM/NoPadding");
+        gcm.init(Cipher.DECRYPT_MODE, new SecretKeySpec(aes, "AES"), new GCMParameterSpec(GCM_TAG_BITS, iv));
+        return gcm.doFinal(ctTag);
+    }
+
+    /* ===================== GP encrypt/decrypt ===================== */
+
+    /** Cifra valor para guardar em settings (usa AES-GCM com master key em settings). */
+    public String encryptForGP(String plain) {
+        if (plain == null || plain.trim().isEmpty()) return "";
+        try {
+            SecretKey key = loadOrCreateMasterKey();
+            if (key == null) {
+                // fallback (último recurso)
+                return "{b64}" + Base64.getEncoder().encodeToString(plain.getBytes(StandardCharsets.UTF_8));
+            }
+            byte[] iv = new byte[GCM_IV_BYTES];
+            new SecureRandom().nextBytes(iv);
+
+            Cipher gcm = Cipher.getInstance("AES/GCM/NoPadding");
+            gcm.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_BITS, iv));
+            byte[] ct = gcm.doFinal(plain.getBytes(StandardCharsets.UTF_8));
+
+            ByteBuffer bb = ByteBuffer.allocate(iv.length + ct.length);
+            bb.put(iv).put(ct);
+            String payload = Base64.getEncoder().encodeToString(bb.array());
+            return "{v1}" + payload;
+        } catch (Exception e) {
+            return "{b64}" + Base64.getEncoder().encodeToString(plain.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    /** Descifra valor guardado por {@link #encryptForGP} ({v1}) e suporta fallback {b64} / plain. */
+    public String decryptFromGP(String stored) {
+        if (stored == null || stored.trim().isEmpty()) return "";
+        try {
+            if (stored.startsWith("{v1}")) {
+                String b64 = stored.substring("{v1}".length());
+                byte[] blob = Base64.getDecoder().decode(b64);
+                if (blob.length < GCM_IV_BYTES + 16) return "";
+
+                byte[] iv = slice(blob, 0, GCM_IV_BYTES);
+                byte[] ct = slice(blob, GCM_IV_BYTES, blob.length);
+
+                SecretKey key = loadOrCreateMasterKey();
+                if (key == null) return "";
+
+                Cipher gcm = Cipher.getInstance("AES/GCM/NoPadding");
+                gcm.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_BITS, iv));
+                byte[] clear = gcm.doFinal(ct);
+                return new String(clear, StandardCharsets.UTF_8);
+            }
+            if (stored.startsWith("{b64}")) {
+                String b64 = stored.substring("{b64}".length());
+                byte[] bytes = Base64.getDecoder().decode(b64);
+                return new String(bytes, StandardCharsets.UTF_8);
+            }
+            return stored; // plain
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    public String encryptCompact(String jsonUtf8, PublicKey serverPublic) throws Exception {
+        // gerar chave AES-256
+        javax.crypto.KeyGenerator kg = javax.crypto.KeyGenerator.getInstance("AES");
+        kg.init(256, new java.security.SecureRandom());
+        javax.crypto.SecretKey aes = kg.generateKey();
+
+        // cifrar dados com AES-GCM
+        byte[] iv = new byte[12];
+        new java.security.SecureRandom().nextBytes(iv);
+        javax.crypto.Cipher gcm = javax.crypto.Cipher.getInstance("AES/GCM/NoPadding");
+        gcm.init(javax.crypto.Cipher.ENCRYPT_MODE, aes, new javax.crypto.spec.GCMParameterSpec(128, iv));
+        byte[] ct = gcm.doFinal(jsonUtf8.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        // envolver chave AES com RSA-OAEP SHA-256
+        javax.crypto.Cipher rsa = javax.crypto.Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding");
+        rsa.init(javax.crypto.Cipher.ENCRYPT_MODE, serverPublic, OAEP_SHA256_SHA256);
+        byte[] wrapped = rsa.doFinal(aes.getEncoded());
+
+        // blob = wrapped || iv || ct
+        byte[] blob = new byte[wrapped.length + iv.length + ct.length];
+        System.arraycopy(wrapped, 0, blob, 0, wrapped.length);
+        System.arraycopy(iv, 0, blob, wrapped.length, iv.length);
+        System.arraycopy(ct, 0, blob, wrapped.length + iv.length, ct.length);
+
+        return java.util.Base64.getEncoder().encodeToString(blob);
+    }
+
+    /** Assina a STRING base64 (não os bytes decodificados), SHA256withRSA → Base64 */
+    public String signBase64(String dataB64, PrivateKey privateKey) throws Exception {
+        java.security.Signature s = java.security.Signature.getInstance("SHA256withRSA");
+        s.initSign(privateKey);
+        s.update(dataB64.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return java.util.Base64.getEncoder().encodeToString(s.sign());
+    }
+    /* ===================== internals ===================== */
+
+    private static byte[] slice(byte[] a, int from, int to) {
+        int len = to - from;
+        byte[] out = new byte[len];
+        System.arraycopy(a, from, out, 0, len);
+        return out;
+    }
+
+    private volatile SecretKey cachedMaster; // evita hits no DB no hot path
+
+    /** Carrega do settings ou cria uma nova (e persiste) no 1º uso. */
+    private synchronized SecretKey loadOrCreateMasterKey() {
+        if (cachedMaster != null) return cachedMaster;
+
+        // tenta carregar do settings (cacheado pelo SettingService)
+        String b64 = settings.get(CT_KMS_MASTER_KEY_B64, null);
+        try {
+            if (b64 == null || b64.trim().isEmpty()) {
+                // cria 256-bit nova e persiste
+                KeyGenerator kg = KeyGenerator.getInstance("AES");
+                kg.init(AES_BITS, new SecureRandom());
+                SecretKey key = kg.generateKey();
+                String enc = Base64.getEncoder().encodeToString(key.getEncoded());
+
+                // guarda no settings e invalida cache global se necessário
+                settings.upsert(CT_KMS_MASTER_KEY_B64, enc, "SECRET",
+                        "Master key (AES-256) para cifrar valores de settings", true, "system");
+
+                cachedMaster = key;
+                return key;
+            } else {
+                byte[] raw = Base64.getDecoder().decode(b64.trim());
+                cachedMaster = new SecretKeySpec(raw, "AES");
+                return cachedMaster;
+            }
+        } catch (GeneralSecurityException | IllegalArgumentException e) {
+            return null; // o chamador fará fallback {b64}
+        }
+    }
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/crypto/CtCompactCrypto.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/crypto/CtCompactCrypto.java
@@ -229,4 +229,29 @@ public class CtCompactCrypto {
             return null; // o chamador fará fallback {b64}
         }
     }
+
+    private static byte[] decodeSignatureFlexible(String s) {
+        try { return java.util.Base64.getDecoder().decode(s); }
+        catch (IllegalArgumentException e1) {
+            try { return java.util.Base64.getUrlDecoder().decode(s); }
+            catch (IllegalArgumentException e2) {
+                String t = s.replaceAll("\\s+", "");
+                if (t.length() % 2 != 0) throw new IllegalArgumentException("Odd-length hex signature");
+                byte[] out = new byte[t.length() / 2];
+                for (int i = 0; i < out.length; i++) {
+                    out[i] = (byte) Integer.parseInt(t.substring(2*i, 2*i+2), 16);
+                }
+                return out;
+            }
+        }
+    }
+
+    public static boolean verifySignatureOverString(String dataString, String signatureStr,
+                                                    java.security.PublicKey ctPublic) throws Exception {
+        byte[] sig = decodeSignatureFlexible(signatureStr);
+        java.security.Signature s = java.security.Signature.getInstance("SHA256withRSA");
+        s.initVerify(ctPublic);
+        s.update(dataString.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return s.verify(sig);
+    }
 }

--- a/src/main/java/mz/org/csaude/sespcet/api/dto/ClientDataDTO.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/dto/ClientDataDTO.java
@@ -1,0 +1,6 @@
+package mz.org.csaude.sespcet.api.dto;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public record ClientDataDTO(String data, String signature, String keyId) {}

--- a/src/main/java/mz/org/csaude/sespcet/api/dto/EncryptedRequestDTO.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/dto/EncryptedRequestDTO.java
@@ -1,0 +1,6 @@
+package mz.org.csaude.sespcet.api.dto;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public record EncryptedRequestDTO(String data, String signature) {}

--- a/src/main/java/mz/org/csaude/sespcet/api/entity/Setting.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/entity/Setting.java
@@ -1,0 +1,56 @@
+package mz.org.csaude.sespcet.api.entity;
+
+import io.micronaut.core.annotation.Creator;
+import io.micronaut.serde.annotation.Serdeable;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import mz.org.csaude.sespcet.api.base.BaseEntity;
+
+@Schema(name = "settings", description = "Representa configurações do sistema")
+@Entity(name = "settings")
+@Table(name = "settings")
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Serdeable.Deserializable
+@ToString
+public class Setting extends BaseEntity {
+
+    public static final String MESSAGING_BROKER = "MESSAGING_BROKER";
+
+    @NotNull
+    @Column(name = "DESIGNATION", nullable = false)
+    private String designation;
+
+    @NotNull
+    @Column(name = "SETTING_VALUE", nullable = false)
+    private String value;
+
+    @NotNull
+    @Column(name = "SETTING_TYPE", nullable = false)
+    private String type;
+
+    @NotNull
+    @Column(name = "ENABLED", nullable = false)
+    private Boolean enabled;
+
+    @NotNull
+    @Column(name = "DESCRIPTION", nullable = false)
+    private String description;
+
+    @Creator
+    public Setting(){}
+
+    public Setting(String designation, String value, String type, Boolean enabled, String description) {
+        this.designation = designation;
+        this.value = value;
+        this.type = type;
+        this.enabled = enabled;
+        this.description = description;
+    }
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/http/CtAuthFilter.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/http/CtAuthFilter.java
@@ -1,0 +1,73 @@
+// src/main/java/mz/org/csaude/sespcet/api/http/CtAuthFilter.java
+package mz.org.csaude.sespcet.api.http;
+
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.filter.ClientFilterChain;
+import io.micronaut.http.filter.HttpClientFilter;
+import jakarta.inject.Singleton;
+import mz.org.csaude.sespcet.api.oauth.OAuthService;
+import mz.org.csaude.sespcet.api.service.SettingService;
+import org.reactivestreams.Publisher;
+
+import java.net.URI;
+import java.util.Locale;
+
+import static mz.org.csaude.sespcet.api.config.SettingKeys.CT_BASE_URL;
+
+@Singleton
+@Filter(patterns = "/**")
+public class CtAuthFilter implements HttpClientFilter {
+
+    public static final String BYPASS_HEADER = "X-Auth-Bypass";
+
+    private final OAuthService oauth;
+    private final SettingService settings;
+
+    public CtAuthFilter(OAuthService oauth, SettingService settings) {
+        this.oauth = oauth;
+        this.settings = settings;
+    }
+
+    @Override
+    public Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
+        try {
+            // 0) explicit opt-out
+            String bypass = request.getHeaders().get(BYPASS_HEADER);
+            if (bypass != null && bypass.equalsIgnoreCase("true")) {
+                return chain.proceed(request);
+            }
+
+            // 1) if Authorization already set (e.g., Basic for token call), don't touch
+            if (request.getHeaders().contains(HttpHeaders.AUTHORIZATION)) {
+                return chain.proceed(request);
+            }
+
+            // 2) only target CT host
+            URI target = request.getUri();
+            URI ctBase = URI.create(settings.get(CT_BASE_URL, "https://api.comitetarvmisau.co.mz"));
+            if (!equalsIgnoreCase(ctBase.getHost(), target.getHost())) {
+                return chain.proceed(request);
+            }
+
+            // 3) skip register and token endpoints
+            String path = target.getPath() == null ? "" : target.getPath().toLowerCase(Locale.ROOT);
+            if (path.endsWith("/oauth2/token") || path.endsWith("/oauth2/clients")) {
+                return chain.proceed(request);
+            }
+
+            // 4) attach Bearer token
+            request.bearerAuth(oauth.getToken());
+        } catch (Exception ignore) {
+            // best-effort: continue without Bearer
+        }
+        return chain.proceed(request);
+    }
+
+    private static boolean equalsIgnoreCase(String a, String b) {
+        if (a == null) return b == null;
+        return b != null && a.equalsIgnoreCase(b);
+    }
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/oauth/OAuthService.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/oauth/OAuthService.java
@@ -9,6 +9,7 @@ import io.micronaut.http.client.annotation.Client;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import mz.org.csaude.sespcet.api.crypto.CtCompactCrypto;
+import mz.org.csaude.sespcet.api.http.CtAuthFilter;
 import mz.org.csaude.sespcet.api.service.SettingService;
 
 import java.net.URI;
@@ -65,7 +66,8 @@ public class OAuthService {
 
         HttpRequest<String> req = HttpRequest.POST(uri, encodeForm(form))
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
-                .header(HttpHeaders.AUTHORIZATION, basicAuth(clientId(), clientSecret()));
+                .header(HttpHeaders.AUTHORIZATION, basicAuth(clientId(), clientSecret()))
+                .header(CtAuthFilter.BYPASS_HEADER, "true");
 
         Map<String, Object> body;
         try {
@@ -85,7 +87,8 @@ public class OAuthService {
 
         HttpRequest<String> req = HttpRequest.POST(uri, encodeForm(form))
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
-                .header(HttpHeaders.AUTHORIZATION, basicAuth(clientId(), clientSecret()));
+                .header(HttpHeaders.AUTHORIZATION, basicAuth(clientId(), clientSecret()))
+                .header(CtAuthFilter.BYPASS_HEADER, "true");
 
         Map<String, Object> body;
         try {

--- a/src/main/java/mz/org/csaude/sespcet/api/oauth/OAuthService.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/oauth/OAuthService.java
@@ -1,0 +1,162 @@
+package mz.org.csaude.sespcet.api.oauth;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import mz.org.csaude.sespcet.api.crypto.CtCompactCrypto;
+import mz.org.csaude.sespcet.api.service.SettingService;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static mz.org.csaude.sespcet.api.config.SettingKeys.*;
+
+@Singleton
+public class OAuthService {
+
+    @Inject @Client("/") HttpClient http;
+
+    private final SettingService settings;
+    private final CtCompactCrypto crypto;
+
+    private volatile String token;
+    private volatile String refreshToken;
+    private volatile long expEpoch;
+
+    public OAuthService(SettingService settings, CtCompactCrypto crypto) {
+        this.settings = settings;
+        this.crypto = crypto;
+    }
+
+    public synchronized String getToken() {
+        long now = System.currentTimeMillis() / 1000;
+        if (token != null && now < expEpoch - 30) return token;
+
+        if (refreshToken != null) {
+            try {
+                refreshWithRefreshToken();
+                return token;
+            } catch (Exception ignore) { /* fallback */ }
+        }
+        obtainWithClientCredentials();
+        return token;
+    }
+
+    public String getAuthorizationHeader() {
+        return "Bearer " + getToken();
+    }
+
+    /* --------------- internals --------------- */
+
+    private void obtainWithClientCredentials() {
+        URI uri = tokenUri();
+
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("grant_type", "client_credentials");
+        form.put("scope", "read write");
+
+        HttpRequest<String> req = HttpRequest.POST(uri, encodeForm(form))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, basicAuth(clientId(), clientSecret()));
+
+        Map<String, Object> body;
+        try {
+            body = http.toBlocking().retrieve(req, Argument.mapOf(String.class, Object.class));
+        } catch (io.micronaut.http.client.exceptions.HttpClientResponseException e) {
+            throw new IllegalStateException("OAuth error: " + e.getStatus(), e);
+        }
+        applyTokenResponse(body);
+    }
+
+    private void refreshWithRefreshToken() {
+        URI uri = tokenUri();
+
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("grant_type", "refresh_token");
+        form.put("refresh_token", refreshToken);
+
+        HttpRequest<String> req = HttpRequest.POST(uri, encodeForm(form))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, basicAuth(clientId(), clientSecret()));
+
+        Map<String, Object> body;
+        try {
+            body = http.toBlocking().retrieve(req, Argument.mapOf(String.class, Object.class));
+        } catch (io.micronaut.http.client.exceptions.HttpClientResponseException e) {
+            throw new IllegalStateException("OAuth refresh error: " + e.getStatus(), e);
+        }
+        applyTokenResponse(body);
+    }
+
+    private void applyTokenResponse(Map<String, Object> body) {
+        this.token = optStr(body, "access_token")
+                .orElseThrow(() -> new IllegalStateException("Missing access_token"));
+
+        long now = System.currentTimeMillis() / 1000;
+        long expiresIn = optNumber(body, "expires_in").map(Number::longValue).orElse(3600L);
+        this.expEpoch = now + expiresIn;
+
+        this.refreshToken = optStr(body, "refresh_token").orElse(this.refreshToken);
+    }
+
+    /* --------------- settings helpers --------------- */
+
+    private URI tokenUri() {
+        String url = settings.get(CT_OAUTH_TOKEN_URL,
+                settings.get(CT_BASE_URL, "https://api.comitetarvmisau.co.mz") + "/oauth2/token");
+        try {
+            return new URI(url);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid token URL in settings: " + url, e);
+        }
+    }
+
+    private String clientId() {
+        String v = settings.get(CT_OAUTH_CLIENT_ID, "");
+        if (v.isBlank()) throw new IllegalStateException("Missing setting: " + CT_OAUTH_CLIENT_ID);
+        return v;
+    }
+
+    private String clientSecret() {
+        String enc = crypto.decryptFromGP(settings.get(CT_OAUTH_CLIENT_SECRET, ""));
+        if (enc.isBlank()) throw new IllegalStateException("Missing setting: " + CT_OAUTH_CLIENT_SECRET);
+        return crypto.decryptFromGP(enc);
+    }
+
+    /* --------------- utils --------------- */
+
+    private static Optional<String> optStr(Map<String, Object> m, String key) {
+        Object v = m.get(key);
+        return (v instanceof String s && !s.isBlank()) ? Optional.of(s) : Optional.empty();
+    }
+
+    private static Optional<Number> optNumber(Map<String, Object> m, String key) {
+        Object v = m.get(key);
+        return (v instanceof Number n) ? Optional.of(n) : Optional.empty();
+    }
+
+    private static String basicAuth(String clientId, String clientSecret) {
+        String auth = clientId + ":" + clientSecret;
+        String b64 = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + b64;
+    }
+
+    private static String encodeForm(Map<String, String> form) {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, String> e : form.entrySet()) {
+            if (sb.length() > 0) sb.append('&');
+            sb.append(URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8));
+            sb.append('=');
+            sb.append(URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/repository/SettingRepository.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/repository/SettingRepository.java
@@ -1,0 +1,21 @@
+package mz.org.csaude.sespcet.api.repository;
+
+import io.micronaut.data.annotation.Repository;
+import io.micronaut.data.jpa.repository.JpaRepository;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Slice;
+import mz.org.csaude.sespcet.api.entity.Setting;
+import mz.org.csaude.sespcet.api.util.LifeCycleStatus;
+
+import java.util.Optional;
+
+@Repository
+public interface SettingRepository extends JpaRepository<Setting, Long> {
+    Optional<Setting> findByDesignation(String designation);
+
+    Page<Setting> findByDesignationIlike(String designation, Pageable pageable);
+
+    Optional<Setting> findByDesignationAndEnabledTrueAndLifeCycleStatusNotEquals(
+            String designation, LifeCycleStatus lifeCycleStatus);
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/service/EctWebhookService.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/service/EctWebhookService.java
@@ -1,0 +1,117 @@
+// mz/org/csaude/sespcet/api/service/EctWebhookService.java
+package mz.org.csaude.sespcet.api.service;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.*;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.json.JsonMapper;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import mz.org.csaude.sespcet.api.crypto.CtCompactCrypto;
+import mz.org.csaude.sespcet.api.dto.ClientDataDTO;
+import mz.org.csaude.sespcet.api.oauth.OAuthService;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.*;
+
+import static mz.org.csaude.sespcet.api.config.SettingKeys.*;
+
+@Singleton
+public class EctWebhookService {
+
+    @Inject @Client("/") HttpClient http;
+
+    private final SettingService settings;
+    private final OAuthService oauth;
+    private final CtCompactCrypto crypto;
+    private final JsonMapper jsonMapper;
+
+    public EctWebhookService(SettingService settings, OAuthService oauth, CtCompactCrypto crypto, JsonMapper jsonMapper) {
+        this.settings = settings;
+        this.oauth = oauth;
+        this.crypto = crypto;
+        this.jsonMapper = jsonMapper;
+    }
+
+    /** Garante registo (idempotente). */
+    public void ensureRegistered() {
+        boolean already = settings.getBoolean(CT_WEBHOOK_REGISTERED, false);
+        if (!already) register();
+    }
+
+    /** Registo no eCT (POST /api/webhooks). */
+    public void register() {
+        try {
+            URI uri = buildCtUri("/api/webhooks"); // se preferir, torne configurável
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("url", settings.get(CT_WEBHOOK_URL, "http://localhost:8383/api/public/webhook/e-ft"));
+            payload.put("events", eventsFromSettings());
+            payload.put("clientKeyId", settings.get(CT_KEYS_CLIENT_KEY_ID, "sespct-api-key-1"));
+
+            ClientDataDTO body = buildEncryptedEnvelope(payload);
+            HttpRequest<ClientDataDTO> req = HttpRequest.POST(uri, body)
+                    .contentType(MediaType.APPLICATION_JSON_TYPE)
+                    .bearerAuth(oauth.getToken()); // ou deixe o CtAuthFilter adicionar
+
+            http.toBlocking().retrieve(req, Argument.mapOf(String.class, Object.class));
+            settings.upsert(CT_WEBHOOK_REGISTERED, "true", "BOOLEAN", "Webhook registado no eCT", true, "system");
+        } catch (Exception e) {
+            throw new IllegalStateException("Falhou o registo de webhook no eCT", e);
+        }
+    }
+
+    /** Anulação no eCT (DELETE /api/webhooks). */
+    public void unregister() {
+        try {
+            URI uri = buildCtUri("/api/webhooks");
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("url", settings.get(CT_WEBHOOK_URL, ""));
+
+            ClientDataDTO body = buildEncryptedEnvelope(payload);
+            HttpRequest<ClientDataDTO> req = HttpRequest.DELETE(uri, body)
+                    .contentType(MediaType.APPLICATION_JSON_TYPE)
+                    .bearerAuth(oauth.getToken());
+
+            http.toBlocking().retrieve(req, Argument.VOID);
+            settings.upsert(CT_WEBHOOK_REGISTERED, "false", "BOOLEAN", "Webhook registado no eCT", true, "system");
+        } catch (Exception e) {
+            throw new IllegalStateException("Falhou a anulação de webhook no eCT", e);
+        }
+    }
+
+    /* ------------ helpers ------------ */
+
+    private ClientDataDTO buildEncryptedEnvelope(Map<String,Object> payload) throws Exception {
+        String json = new String(jsonMapper.writeValueAsBytes(payload), StandardCharsets.UTF_8);
+
+        String ctPubPem   = settings.get(CT_KEYS_CT_PUBLIC_PEM, null);
+        String apiPrvPem  = settings.get(CT_KEYS_SESPCTAPI_PRIVATE_PEM, null);
+        if (ctPubPem == null || apiPrvPem == null) {
+            throw new IllegalStateException("Chaves ausentes (CT public ou API private)");
+        }
+        PublicKey  ctPublic   = crypto.readPublicKeyPem(ctPubPem);
+        PrivateKey apiPrivate = crypto.readPrivateKeyPem(apiPrvPem);
+
+        String dataB64 = crypto.encryptCompact(json, ctPublic);
+        String sigB64  = crypto.signBase64(dataB64, apiPrivate);
+        String keyId   = settings.get(CT_KEYS_CLIENT_KEY_ID, "sespct-api-key-1");
+
+        return new ClientDataDTO(dataB64, sigB64, keyId);
+    }
+
+    private List<String> eventsFromSettings() {
+        String csv = settings.get(CT_WEBHOOK_EVENTS, "PEDIDO_REPLIED,PEDIDO_UPDATED,RESPOSTA_UPDATED");
+        String[] parts = csv.split("\\s*,\\s*");
+        return Arrays.asList(parts);
+    }
+
+    private URI buildCtUri(String path) throws URISyntaxException {
+        String base = settings.get(CT_BASE_URL, "https://api.comitetarvmisau.co.mz");
+        return io.micronaut.http.uri.UriBuilder.of(base).path(path).build();
+    }
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/service/SettingService.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/service/SettingService.java
@@ -1,0 +1,83 @@
+package mz.org.csaude.sespcet.api.service;
+
+import io.micronaut.cache.annotation.CacheInvalidate;
+import io.micronaut.cache.annotation.Cacheable;
+import jakarta.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import mz.org.csaude.sespcet.api.entity.Setting;
+import mz.org.csaude.sespcet.api.repository.SettingRepository;
+import mz.org.csaude.sespcet.api.util.LifeCycleStatus;
+import mz.org.csaude.sespcet.api.util.Utilities;
+
+import java.util.Locale;
+import java.util.Optional;
+
+@Singleton
+@RequiredArgsConstructor
+public class SettingService {
+
+    private final SettingRepository repo;
+
+    @Cacheable("settings")
+    protected Optional<String> getRawValueCached(String key) {
+        return repo.findByDesignationAndEnabledTrueAndLifeCycleStatusNotEquals(key, LifeCycleStatus.DELETED)
+                .map(Setting::getValue)
+                .map(String::trim)
+                .filter(v -> !v.isEmpty());
+    }
+
+    public String get(String key, String def) {
+        return getRawValueCached(key).orElse(def);
+    }
+
+    public boolean getBoolean(String key, boolean def) {
+        String v = get(key, null);
+        return Utilities.stringHasValue(v) ? Boolean.parseBoolean(v) : def;
+    }
+
+    public int getInt(String key, int def) {
+        String v = get(key, null);
+        try { return Utilities.stringHasValue(v) ? Integer.parseInt(v) : def; }
+        catch (NumberFormatException e) { return def; }
+    }
+
+    public long getLong(String key, long def) {
+        String v = get(key, null);
+        try { return Utilities.stringHasValue(v) ? Long.parseLong(v) : def; }
+        catch (NumberFormatException e) { return def; }
+    }
+
+    public double getDouble(String key, double def) {
+        String v = get(key, null);
+        try { return Utilities.stringHasValue(v) ? Double.parseDouble(v) : def; }
+        catch (NumberFormatException e) { return def; }
+    }
+
+    public <E extends Enum<E>> E getEnum(String key, Class<E> type, E def) {
+        String v = get(key, null);
+        if (!Utilities.stringHasValue(v)) return def;
+        try { return Enum.valueOf(type, v.trim().toUpperCase(Locale.ROOT)); }
+        catch (IllegalArgumentException ex) { return def; }
+    }
+
+    /** Upsert + invalidação da cache dessa key. */
+    @CacheInvalidate(cacheNames = "settings") // invalida usando 'key' como parâmetro do método
+    public void upsert(String key, String value, String type, String description, boolean enabled, String actor) {
+        Setting s = repo.findByDesignation(key).orElseGet(Setting::new);
+        s.setDesignation(key);
+        s.setValue(value);
+        s.setType(type);
+        s.setEnabled(enabled);
+        s.setDescription(description);
+        if (s.getId() == null) {
+            s.setCreatedBy(actor != null ? actor : "system");
+            s.setLifeCycleStatus(LifeCycleStatus.ACTIVE);
+        } else {
+            s.setUpdatedBy(actor != null ? actor : "system");
+        }
+        repo.save(s);
+    }
+
+    @CacheInvalidate(cacheNames = "settings", all = true)
+    public void evictAll() {}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,10 @@ micronaut:
   server:
     port: 8383
     context-path: /api
+  caches:
+    settings:
+      expire-after-write: 5m
+      maximum-size: 500
   security:
     authentication: bearer
     token:
@@ -46,3 +50,8 @@ datasources:
     driver-class-name: org.mariadb.jdbc.Driver
     maximum-pool-size: 50
     minimum-idle: 5
+---
+sespct:
+  ct:
+    bootstrap:
+      enabled: true

--- a/src/main/resources/db/changelog/01-schema.xml
+++ b/src/main/resources/db/changelog/01-schema.xml
@@ -5,6 +5,83 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
-    <changeSet id="01" author="username">
+    <!-- Criação da tabela SETTINGS baseada em BaseEntity + Setting -->
+    <changeSet id="001-create-settings" author="voloide">
+        <!-- Se já existir, não recria -->
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="settings"/>
+            </not>
+        </preConditions>
+
+        <!-- Para MySQL/MariaDB: engine + charset -->
+        <createTable tableName="settings" >
+
+            <!-- BaseEntity -->
+            <column name="ID" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" primaryKeyName="pk_settings"/>
+            </column>
+
+            <column name="UUID" type="VARCHAR(50)">
+                <constraints nullable="false" unique="true" uniqueConstraintName="uk_settings_uuid"/>
+            </column>
+
+            <column name="CREATED_BY" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="CREATED_AT" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="UPDATED_BY" type="VARCHAR(50)"/>
+
+            <column name="UPDATED_AT" type="TIMESTAMP"/>
+
+            <column name="LIFE_CYCLE_STATUS" type="VARCHAR(100)">
+                <constraints nullable="false"/>
+            </column>
+
+            <!-- Campos específicos de Setting -->
+            <column name="DESIGNATION" type="VARCHAR(150)">
+                <constraints nullable="false"/>
+            </column>
+
+            <!-- ACEITA TEXTOS MUITO LONGOS -->
+            <column name="SETTING_VALUE" type="LONGTEXT">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="SETTING_TYPE" type="VARCHAR(100)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="ENABLED" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+
+            <!-- descrição pode ser grande; TEXT é suficiente -->
+            <column name="DESCRIPTION" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <!-- Unicidade por DESIGNATION (cada chave de configuração é única) -->
+        <addUniqueConstraint tableName="settings"
+                             columnNames="DESIGNATION"
+                             constraintName="uk_settings_designation"/>
+
+        <!-- Índices úteis -->
+        <createIndex tableName="settings" indexName="idx_settings_designation">
+            <column name="DESIGNATION"/>
+        </createIndex>
+
+        <createIndex tableName="settings" indexName="idx_settings_enabled">
+            <column name="ENABLED"/>
+        </createIndex>
+
+        <createIndex tableName="settings" indexName="idx_settings_created_at">
+            <column name="CREATED_AT"/>
+        </createIndex>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
…auto Bearer auth

- Add Dockerfile and docker-compose example (no DB container), volumes for logs/resources
- Create Setting entity + Liquibase changelog; SettingRepository/Service with Caffeine cache
- Add SettingKeys (CT_* + SESPCT_API_BASE_URL + CT_WEBHOOK_URL + CT_KMS_MASTER_KEY_B64)
- Seed defaults at boot (CT base/register/token URLs, SESPCT_API_BASE_URL, CT_WEBHOOK_URL)
- Implement CtCompactCrypto:
  - AES-GCM {v1} encrypt/decrypt for settings using master key (CT_KMS_MASTER_KEY_B64)
  - RSA OAEP(sha256) compact encrypt/decrypt; sign/verify helpers
- Migrate OAuthService to Micronaut HttpClient; token cache + refresh; config-driven
- CtBootstrap (ServerStartupEvent):
  - idempotent run + retry prefetch of first token
  - generate API RSA key pair if missing
  - register OAuth client if needed
  - after first token, ensure webhook registration (idempotent)
- EctWebhookService: build encrypted+signed envelope (ClientDataDTO) and call eCT
  - register/unregister endpoints
- WebhookController: receive notifications, verify CT signature, decrypt with API private key
- CtAuthFilter: automatically adds Bearer token for CT host; skips /oauth2/token & /oauth2/clients (supports X-Auth-Bypass header)
- Replace Jackson ObjectMapper injection with Micronaut JsonMapper