### PR TITLE
feat(webhook): ingest assíncrono + ACK de consumo para eCT

### DIFF
--- a/src/main/java/mz/org/csaude/sespcet/api/config/SettingKeys.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/config/SettingKeys.java
@@ -3,26 +3,58 @@ package mz.org.csaude.sespcet.api.config;
 public final class SettingKeys {
     private SettingKeys() {}
 
+    // =========================
     // CT / eCT integration
-    public static final String CT_BASE_URL                      = "sesp.ct.baseUrl";
-    public static final String CT_OAUTH_TOKEN_URL               = "sesp.ct.oauth.tokenUrl";
-    public static final String CT_OAUTH_CLIENT_ID               = "sesp.ct.oauth.clientId";
-    public static final String CT_OAUTH_CLIENT_SECRET           = "sesp.ct.oauth.clientSecret";
+    // =========================
+    public static final String CT_BASE_URL                   = "sesp.ct.baseUrl";
+    public static final String CT_OAUTH_TOKEN_URL            = "sesp.ct.oauth.tokenUrl";
+    public static final String CT_OAUTH_CLIENT_ID            = "sesp.ct.oauth.clientId";
+    public static final String CT_OAUTH_CLIENT_SECRET        = "sesp.ct.oauth.clientSecret";
 
-    public static final String CT_KEYS_CT_PUBLIC_PEM            = "sesp.ct.keys.ctPublicPem";
-    public static final String CT_KEYS_SESPCTAPI_PUBLIC_PEM     = "sesp.ct.keys.sespctApiPublicPem";
-    public static final String CT_KEYS_SESPCTAPI_PRIVATE_PEM    = "sesp.ct.keys.sespctApiPrivatePem";
-    public static final String CT_KEYS_CLIENT_KEY_ID            = "sesp.ct.keys.clientKeyId";
+    public static final String CT_KEYS_CT_PUBLIC_PEM         = "sesp.ct.keys.ctPublicPem";
+    public static final String CT_KEYS_SESPCTAPI_PUBLIC_PEM  = "sesp.ct.keys.sespctApiPublicPem";
+    public static final String CT_KEYS_SESPCTAPI_PRIVATE_PEM = "sesp.ct.keys.sespctApiPrivatePem";
+    public static final String CT_KEYS_CLIENT_KEY_ID         = "sesp.ct.keys.clientKeyId";
 
-    public static final String CT_WEBHOOK_URL                   = "sesp.ct.webhook.url";
-    public static final String CT_REGISTER_URL                  = "sesp.ct.register.url";
-    public static final String CT_DEFAULT_FACILITY              = "sesp.ct.facilityCode";
-    public static final String CT_SINCE_ISO                     = "sesp.ct.since";
+    public static final String CT_REGISTER_URL               = "sesp.ct.register.url";
+    public static final String CT_DEFAULT_FACILITY           = "sesp.ct.facilityCode";
+    public static final String CT_SINCE_ISO                  = "sesp.ct.since";
 
-    /** Master key (AES-256, Base64) usada para cifrar valores em settings */
-    public static final String CT_KMS_MASTER_KEY_B64            = "sesp.ct.kms.masterKeyB64";
+    /** Master key (AES-256 Base64) usada para cifrar valores em settings */
+    public static final String CT_KMS_MASTER_KEY_B64         = "sesp.ct.kms.masterKeyB64";
 
-    public static final String CT_WEBHOOK_REGISTERED    = "sesp.ct.webhook.registered"; // boolean "true"/"false"
-    public static final String CT_WEBHOOK_EVENTS        = "sesp.ct.webhook.events";     // CSV, ex: PEDIDO_REPLIED,PEDIDO_UPDATED,RESPOSTA_UPDATED
-    public static final String SESPCT_API_BASE_URL      = "sespct.api.baseUrl";
+    // =========================
+    // Webhook
+    // =========================
+    public static final String CT_WEBHOOK_URL                        = "sesp.ct.webhook.url";
+    public static final String CT_WEBHOOK_REGISTERED                 = "sesp.ct.webhook.registered";       // boolean "true"/"false"
+    public static final String CT_WEBHOOK_EVENTS                     = "sesp.ct.webhook.events";           // CSV, ex: PEDIDO_REPLIED,RESPOSTA_ADDED,RESPOSTA_UPDATED
+
+    // Novas chaves para payload/controlo de entrega do webhook
+    public static final String CT_WEBHOOK_SECRET                     = "sesp.ct.webhook.secret";
+    public static final String CT_WEBHOOK_TIMEOUT_SECONDS            = "sesp.ct.webhook.timeoutSeconds";
+    public static final String CT_WEBHOOK_RETRY_MAX_ATTEMPTS         = "sesp.ct.webhook.retry.maxAttempts";
+    public static final String CT_WEBHOOK_RETRY_BACKOFF_SECONDS      = "sesp.ct.webhook.retry.backoffSeconds";
+    /** Tamanho dos lotes ao enviar pedidoIds no registo do webhook */
+    public static final String CT_WEBHOOK_PAGINATION_SIZE            = "sesp.ct.webhook.paginationSize";
+
+    // =========================
+    // Sync
+    // =========================
+    public static final String CT_SYNC_ENABLED               = "sesp.ct.sync.enabled";
+    public static final String CT_SYNC_CRON                  = "sesp.ct.sync.cron";
+    public static final String CT_SYNC_ZONE                  = "sesp.ct.sync.zone";
+    /** Limite por página no fetch do eCT (backward-compat) */
+    public static final String CT_SYNC_LIMIT                 = "sesp.ct.sync.limit";
+    /** Alternativa explícita para limite de página */
+    public static final String CT_SYNC_PAGE_LIMIT            = "sesp.ct.sync.pageLimit";
+    public static final String CT_SYNC_CURSOR                = "sesp.ct.sync.cursor";
+    public static final String CT_SYNC_LAST_RUN_ISO          = "sesp.ct.sync.lastRunIso";
+
+    // =========================
+    // Outros
+    // =========================
+    public static final String SESPCT_API_BASE_URL           = "sespct.api.baseUrl";
+    public static final String CT_ENDPOINT_RESPOSTAS_CONSUMED = "sesp.ct.endpoints.respostas.consumed";
+
 }

--- a/src/main/java/mz/org/csaude/sespcet/api/controller/PedidoController.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/controller/PedidoController.java
@@ -29,7 +29,6 @@ import mz.org.csaude.sespcet.api.service.PedidoService;
 import mz.org.csaude.sespcet.api.service.SettingService;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static mz.org.csaude.sespcet.api.config.SettingKeys.CT_KEYS_SESPCTAPI_PRIVATE_PEM;
@@ -69,7 +68,6 @@ public class PedidoController extends BaseController {
                         // Chave privada da nossa API
                         String apiPrivateKey = settings.get(CT_KEYS_SESPCTAPI_PRIVATE_PEM, null);
                         return ctCompactCrypto.buildEncryptedEnvelope(
-                                Map.of("pedidoId", pedido.getPedidoIdCt()),
                                 clientPublicKey,
                                 apiPrivateKey,
                                 pedido.getPayload()

--- a/src/main/java/mz/org/csaude/sespcet/api/controller/RespostaController.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/controller/RespostaController.java
@@ -24,7 +24,6 @@ import mz.org.csaude.sespcet.api.service.RespostaService;
 import mz.org.csaude.sespcet.api.service.SettingService;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static mz.org.csaude.sespcet.api.config.SettingKeys.CT_KEYS_SESPCTAPI_PRIVATE_PEM;
@@ -69,7 +68,7 @@ public class RespostaController extends BaseController {
 
                         // Cria envelope encriptado e assinado
                         return ctCompactCrypto.buildEncryptedEnvelope(
-                                Map.of("respostaId", resposta.getRespostaIdCt()), // metadados adicionais
+                                // metadados adicionais
                                 clientPublicKey,
                                 apiPrivateKey,
                                 resposta.getPayload()

--- a/src/main/java/mz/org/csaude/sespcet/api/controller/WebhookController.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/controller/WebhookController.java
@@ -8,12 +8,18 @@ import lombok.extern.slf4j.Slf4j;
 import mz.org.csaude.sespcet.api.crypto.CtCompactCrypto;
 import mz.org.csaude.sespcet.api.dto.EncryptedRequestDTO;
 import mz.org.csaude.sespcet.api.service.SettingService;
+import mz.org.csaude.sespcet.api.service.WebhookIngestService;
+import io.micronaut.json.JsonMapper;
 
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
 
-import static mz.org.csaude.sespcet.api.config.SettingKeys.*;
+import static mz.org.csaude.sespcet.api.config.SettingKeys.CT_KEYS_CT_PUBLIC_PEM;
+import static mz.org.csaude.sespcet.api.config.SettingKeys.CT_KEYS_SESPCTAPI_PRIVATE_PEM;
 
 @Secured(SecurityRule.IS_ANONYMOUS)
 @Controller("/public/webhook/ect")
@@ -22,56 +28,146 @@ public class WebhookController {
 
     private final SettingService settings;
     private final CtCompactCrypto crypto;
+    private final WebhookIngestService ingest;
+    private final JsonMapper json;
 
-    public WebhookController(SettingService settings, CtCompactCrypto crypto) {
+    public WebhookController(SettingService settings,
+                             CtCompactCrypto crypto,
+                             WebhookIngestService ingest,
+                             JsonMapper json) {
         this.settings = settings;
         this.crypto = crypto;
+        this.ingest = ingest;
+        this.json = json;
     }
 
+    /**
+     * Recebe notificações do eCT (cifradas + assinadas) e devolve ACK cifrado com os pedidoIds consumidos:
+     * Payload claro da resposta:
+     * {
+     *   "status": "CONSUMED",
+     *   "pedidoIds": [70855, 70856, ...],
+     *   "timestamp": "2025-09-11T08:15:30Z"
+     * }
+     */
     @Post
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.APPLICATION_JSON)
     public HttpResponse<?> receive(@Body EncryptedRequestDTO dto) {
         try {
             if (dto == null || dto.data() == null || dto.signature() == null) {
-                return HttpResponse.badRequest("Missing data/signature");
+                return HttpResponse.badRequest(mapPlainError("Missing data/signature"));
             }
 
-            // logging para diagnóstico
-            log.info("Webhook arrived: dataB64Len={}, sigLen={}, sigHead='{}'",
-                    dto.data().length(),
-                    dto.signature().length(),
-                    dto.signature().length() >= 16 ? dto.signature().substring(0, 16) : dto.signature());
-
+            // chaves
             String ctPubPem  = settings.get(CT_KEYS_CT_PUBLIC_PEM, null);
             String apiPrvPem = settings.get(CT_KEYS_SESPCTAPI_PRIVATE_PEM, null);
             if (ctPubPem == null || apiPrvPem == null) {
-                return HttpResponse.status(HttpStatus.PRECONDITION_FAILED, "Missing crypto keys");
+                return HttpResponse.status(HttpStatus.PRECONDITION_FAILED)
+                        .body(mapPlainError("Missing crypto keys"));
             }
 
             PublicKey  ctPublic   = crypto.readPublicKeyPem(ctPubPem);
             PrivateKey apiPrivate = crypto.readPrivateKeyPem(apiPrvPem);
 
-            // 1) verificar assinatura do CT (assina a STRING Base64 de data)
-            boolean ok = crypto.verifySignatureOverString(dto.data(), dto.signature(), ctPublic);
-            if (!ok) {
+            // 1) verificar assinatura (sobre a string Base64 de data)
+            if (!CtCompactCrypto.verifySignatureOverString(dto.data(), dto.signature(), ctPublic)) {
                 log.warn("Webhook signature verification failed");
                 return HttpResponse.unauthorized();
             }
 
             // 2) desencriptar envelope compacto
             byte[] clear = crypto.decryptCompact(dto.data(), apiPrivate);
-            String json = new String(clear, java.nio.charset.StandardCharsets.UTF_8);
+            String incomingJson  = new String(clear, StandardCharsets.UTF_8);
 
-            // 3) processar evento (por agora, apenas log)
-            log.info("Webhook clear payload: {}", json);
-            // TODO: encaminhar para o serviço de domínio
+            // 3) persistir (decide Pedido vs Resposta) e recolher IDs processados (se o serviço o devolver)
+            List<Long> processedIds = safeDistinct(ingest.ingest(incomingJson));
+            if (processedIds == null || processedIds.isEmpty()) {
+                // fallback: extrair pedidoIds do payload recebido (tolerante a formatos)
+                processedIds = safeDistinct(extractPedidoIds(incomingJson));
+            }
 
-            return HttpResponse.ok("ok");
+            // 4) construir ACK claro
+            Map<String, Object> ack = new LinkedHashMap<>();
+            ack.put("status", "CONSUMED");
+            ack.put("pedidoIds", processedIds != null ? processedIds : List.of());
+            ack.put("timestamp", Instant.now().toString());
+
+            String ackJson = new String(json.writeValueAsBytes(ack), StandardCharsets.UTF_8);
+
+            // 5) cifrar + assinar ACK para o eCT (cifra com CT public, assina com nossa private)
+            EncryptedRequestDTO ackEnv = crypto.buildEncryptedEnvelope(ackJson, ctPubPem, apiPrvPem);
+
+            // 6) devolver 200 com envelope JSON
+            return HttpResponse.ok(ackEnv);
+
         } catch (Exception e) {
             log.warn("Erro a processar webhook", e);
-            return HttpResponse.serverError();
+            return HttpResponse.serverError(mapPlainError("internal error"));
         }
     }
 
+    /* ---------------- helpers ---------------- */
+
+    private Map<String, Object> mapPlainError(String msg) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("error", msg);
+        return m;
+    }
+
+    /**
+     * Extrai pedidoIds de um JSON arbitrário.
+     * Procura arrays/objetos com campos: "pedidoIds", "pedido_id", "pedidoId".
+     */
+    @SuppressWarnings("unchecked")
+    private List<Long> extractPedidoIds(String jsonStr) {
+        try {
+            Object root = json.readValue(jsonStr.getBytes(StandardCharsets.UTF_8), Object.class);
+            Set<Long> ids = new LinkedHashSet<>();
+            walk(root, ids);
+            return new ArrayList<>(ids);
+        } catch (Exception e) {
+            log.debug("extractPedidoIds: falha a parsear JSON ({})", e.toString());
+            return List.of();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void walk(Object node, Set<Long> sink) {
+        if (node == null) return;
+
+        if (node instanceof Map<?,?> map) {
+            // campos diretos
+            readIdIntoSink(map.get("pedidoId"), sink);
+            readIdIntoSink(map.get("pedido_id"), sink);
+
+            Object pedidoIds = map.get("pedidoIds");
+            if (pedidoIds instanceof Collection<?> col) {
+                for (Object o : col) readIdIntoSink(o, sink);
+            }
+
+            // descer recursivamente
+            for (Object v : map.values()) walk(v, sink);
+        } else if (node instanceof Iterable<?> it) {
+            for (Object v : it) walk(v, sink);
+        }
+        // outros tipos: ignorar
+    }
+
+    private void readIdIntoSink(Object o, Set<Long> sink) {
+        if (o == null) return;
+        if (o instanceof Number n) {
+            sink.add(n.longValue());
+        } else {
+            String s = String.valueOf(o).trim();
+            if (!s.isEmpty() && s.matches("\\d+")) {
+                try { sink.add(Long.parseLong(s)); } catch (NumberFormatException ignored) {}
+            }
+        }
+    }
+
+    private List<Long> safeDistinct(List<Long> xs) {
+        if (xs == null) return null;
+        return xs.stream().filter(Objects::nonNull).distinct().collect(Collectors.toList());
+    }
 }

--- a/src/main/java/mz/org/csaude/sespcet/api/entity/Pedido.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/entity/Pedido.java
@@ -16,7 +16,7 @@ import java.util.Date;
 public class Pedido extends BaseEntity {
 
     @Column(nullable = false, name = "pedido_id_ct")
-    private String pedidoIdCt;
+    private Long pedidoIdCt;
 
     @Column(nullable = false, name = "facility_code")
     private String facilityCode;

--- a/src/main/java/mz/org/csaude/sespcet/api/entity/Resposta.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/entity/Resposta.java
@@ -16,10 +16,10 @@ import java.util.Date;
 public class Resposta extends BaseEntity {
 
     @Column(nullable = false, name = "resposta_id_ct")
-    private String respostaIdCt;
+    private Long respostaIdCt;
 
     @Column(nullable = false, name = "pedido_id_ct")
-    private String pedidoIdCt;
+    private Long pedidoIdCt;
 
     @Column(nullable = false, name = "facility_code")
     private String facilityCode;

--- a/src/main/java/mz/org/csaude/sespcet/api/jobs/EctDailySyncJob.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/jobs/EctDailySyncJob.java
@@ -1,0 +1,53 @@
+// src/main/java/mz/org/csaude/sespcet/api/jobs/EctDailySyncJob.java
+package mz.org.csaude.sespcet.api.jobs;
+
+import io.micronaut.scheduling.annotation.Scheduled;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import mz.org.csaude.sespcet.api.service.EctSyncService;
+import mz.org.csaude.sespcet.api.service.SettingService;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static mz.org.csaude.sespcet.api.config.SettingKeys.*;
+
+@Slf4j
+@Singleton
+public class EctDailySyncJob {
+
+    private final EctSyncService sync;
+    private final SettingService settings;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    public EctDailySyncJob(EctSyncService sync, SettingService settings) {
+        this.sync = sync;
+        this.settings = settings;
+    }
+
+    // Executa 1x por dia às 02:05 (timezone configurável). Pode mudar via application.yml.
+    @Scheduled(
+            cron = "${sespct.sync.cron:0 5 2 * * ?}",
+            zoneId = "${sespct.sync.zone:Africa/Maputo}"
+    )
+    void runDaily() {
+        if (!settings.getBoolean(CT_SYNC_ENABLED, true)) {
+            log.info("EctDailySyncJob: sync desativado ({}=false).", CT_SYNC_ENABLED);
+            return;
+        }
+        if (!running.compareAndSet(false, true)) {
+            log.info("EctDailySyncJob: já em execução; ignorando.");
+            return;
+        }
+        try {
+            int limit = settings.getInt(CT_SYNC_LIMIT, 50);
+            String cursor = settings.get(CT_SYNC_CURSOR, null);
+            log.info("EctDailySyncJob: iniciando (limit={}, cursor inicial={})", limit, cursor);
+            sync.syncMissingPedidos(limit, cursor, "next");
+            log.info("EctDailySyncJob: concluído.");
+        } catch (Exception e) {
+            log.warn("EctDailySyncJob: falha {}", e.toString());
+        } finally {
+            running.set(false);
+        }
+    }
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/repository/PedidoRepository.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/repository/PedidoRepository.java
@@ -7,13 +7,14 @@ import io.micronaut.data.model.Pageable;
 import mz.org.csaude.sespcet.api.entity.Pedido;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PedidoRepository extends JpaRepository<Pedido, Long> {
 
     Page<Pedido> findByStatus(Pedido.Status status, Pageable pageable);
 
-    Pedido findByPedidoIdCtAndFacilityCode(String pedidoIdCt, String facilityCode);
+    Pedido findByPedidoIdCtAndFacilityCode(long pedidoIdCt, String facilityCode);
 
     // Buscar todos os pedidos correspondentes a uma lista de UUIDs
     List<Pedido> findByUuidIn(List<String> uuids);
@@ -21,6 +22,8 @@ public interface PedidoRepository extends JpaRepository<Pedido, Long> {
     // Salvar/atualizar múltiplos pedidos de uma vez
     @Override
     <S extends Pedido> List<S> saveAll(Iterable<S> entities);
+
+    Optional<Pedido> findByPedidoIdCt(long pedidoIdCt);
 }
 
 

--- a/src/main/java/mz/org/csaude/sespcet/api/repository/RespostaRepository.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/repository/RespostaRepository.java
@@ -7,6 +7,7 @@ import io.micronaut.data.model.Pageable;
 import mz.org.csaude.sespcet.api.entity.Resposta;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RespostaRepository extends JpaRepository<Resposta, Long> {
@@ -15,10 +16,12 @@ public interface RespostaRepository extends JpaRepository<Resposta, Long> {
 
     Page<Resposta> findByStatusAndFacilityCode(Resposta.Status status, String facilityCode, Pageable pageable);
 
-    Resposta findByRespostaIdCtAndFacilityCode(String respostaIdCt, String facilityCode);
+    Resposta findByRespostaIdCtAndFacilityCode(Long respostaIdCt, String facilityCode);
 
     List<Resposta> findByUuidIn(List<String> uuids);
 
     @Override
     <S extends Resposta> List<S> saveAll(Iterable<S> entities);
+
+    Optional<Resposta> findByRespostaIdCt(Long respostaIdCt);
 }

--- a/src/main/java/mz/org/csaude/sespcet/api/service/EctApiClient.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/service/EctApiClient.java
@@ -1,0 +1,159 @@
+package mz.org.csaude.sespcet.api.service;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.*;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.uri.UriBuilder;
+import io.micronaut.json.JsonMapper;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import mz.org.csaude.sespcet.api.crypto.CtCompactCrypto;
+import mz.org.csaude.sespcet.api.dto.EncryptedRequestDTO;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.*;
+
+import static mz.org.csaude.sespcet.api.config.SettingKeys.*;
+
+@Singleton
+public class EctApiClient {
+
+    @Inject @Client("/") HttpClient http;
+
+    private final SettingService settings;
+    private final JsonMapper json;
+    private final CtCompactCrypto crypto;
+
+    public EctApiClient(SettingService settings, JsonMapper json, CtCompactCrypto crypto) {
+        this.settings = settings;
+        this.json = json;
+        this.crypto = crypto;
+    }
+
+    /** Chama POST /api/v1/pedido-troca-linhas/cursor-pagination com paginação por cursor no corpo. Retorna JSON claro. */
+    public String cursorPedidos(Integer limit, String cursor, String direction, Map<String, Object> criteria) throws Exception {
+        if (criteria == null) criteria = java.util.Collections.emptyMap();
+
+        final java.util.Map<String, Object> cursorObj = new java.util.HashMap<>();
+        if (limit != null)     cursorObj.put("limit", limit);
+        cursorObj.put("cursor_type", "id");
+        if (direction != null) cursorObj.put("direction", direction);
+        if (cursor != null)    cursorObj.put("after", cursor); // ajuste se a API usar outra chave
+
+        final java.util.Map<String, Object> payload = new java.util.HashMap<>();
+        payload.put("cursor", cursorObj);
+        payload.put("criteria", criteria);
+
+        String clearJson = new String(json.writeValueAsBytes(payload), StandardCharsets.UTF_8);
+        String ctPubPem  = settings.get(CT_KEYS_CT_PUBLIC_PEM, null);
+        String apiPrvPem = settings.get(CT_KEYS_SESPCTAPI_PRIVATE_PEM, null);
+        EncryptedRequestDTO body = crypto.buildEncryptedEnvelope(clearJson, ctPubPem, apiPrvPem);
+
+        URI uri = base().path("/api/v1/pedido-troca-linhas/cursor-pagination").build();
+        HttpRequest<EncryptedRequestDTO> req = HttpRequest.POST(uri, body)
+                .contentType(MediaType.APPLICATION_JSON_TYPE)
+                .accept(MediaType.APPLICATION_JSON_TYPE);
+
+        EncryptedRequestDTO env = http.toBlocking().retrieve(req, Argument.of(EncryptedRequestDTO.class));
+
+        PublicKey  ctPublic   = crypto.readPublicKeyPem(ctPubPem);
+        PrivateKey apiPrivate = crypto.readPrivateKeyPem(apiPrvPem);
+        if (!CtCompactCrypto.verifySignatureOverString(env.data(), env.signature(), ctPublic)) {
+            throw new IllegalStateException("Invalid server signature");
+        }
+        byte[] clear = crypto.decryptCompact(env.data(), apiPrivate);
+        return new String(clear, StandardCharsets.UTF_8);
+    }
+
+    /** Página parseada (itens + cursor + flag). */
+    public record Page(List<Map<String, Object>> items, String nextCursor, Boolean hasMore) {}
+
+    /** Igual ao cursorPedidos, mas já devolve itens/next_cursor/has_more parseados. */
+    public Page pagePedidos(Integer limit, String cursor, String direction, Map<String, Object> criteria) throws Exception {
+        String clearJson = cursorPedidos(limit, cursor, direction, criteria);
+
+        Map<String, Object> root = json.readValue(
+                clearJson.getBytes(StandardCharsets.UTF_8),
+                Argument.mapOf(String.class, Object.class)
+        );
+        Object d = firstNonNull(root.get("data"), root.get("content"), root);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> items = asListOfMaps(
+                (d instanceof Map ? ((Map<?, ?>) d).get("data") : null)
+        );
+        if (items == null) items = asListOfMaps(firstNonNull(root.get("items"), root.get("results")));
+
+        String next = str(
+                (d instanceof Map ? ((Map<?, ?>) d).get("nextCursor") : null),
+                (d instanceof Map ? path(d, "next_cursor") : null),
+                (d instanceof Map ? path(d, "meta", "next_cursor") : null),
+                (d instanceof Map ? path(d, "pagination", "next_cursor") : null),
+                root.get("nextCursor"),
+                path(root, "next_cursor"),
+                path(root, "meta", "next_cursor"),
+                path(root, "pagination", "next_cursor")
+        );
+
+        Boolean hasMore = bool(
+                (d instanceof Map ? path(d, "meta", "has_more") : null),
+                (d instanceof Map ? path(d, "pagination", "has_more") : null),
+                path(root, "meta", "has_more"),
+                path(root, "pagination", "has_more")
+        );
+
+        return new Page(items != null ? items : java.util.Collections.emptyList(), next, hasMore);
+    }
+
+    private UriBuilder base() {
+        String base = settings.get(CT_BASE_URL, "https://api.comitetarvmisau.co.mz");
+        return UriBuilder.of(base);
+    }
+
+    /* ------------ helpers de parsing locais ------------ */
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> asListOfMaps(Object o) {
+        if (!(o instanceof List<?> list)) return null;
+        List<Map<String, Object>> out = new ArrayList<>(list.size());
+        for (Object el : list) if (el instanceof Map) out.add((Map<String, Object>) el);
+        return out;
+    }
+    private static Object path(Object m, String... keys) {
+        Object cur = m;
+        for (String k : keys) {
+            if (!(cur instanceof Map)) return null;
+            cur = ((Map<?, ?>) cur).get(k);
+        }
+        return cur;
+    }
+    private static Object firstNonNull(Object... xs) {
+        for (Object x : xs) if (x != null) return x;
+        return null;
+    }
+    private static String str(Object... candidates) {
+        for (Object c : candidates) {
+            if (c == null) continue;
+            String s = String.valueOf(c).trim();
+            if (!s.isEmpty() && !"null".equalsIgnoreCase(s)) return s;
+        }
+        return null;
+    }
+    private static Boolean bool(Object... candidates) {
+        for (Object c : candidates) {
+            if (c == null) continue;
+            if (c instanceof Boolean b) return b;
+            if (c instanceof Number n) return n.intValue() != 0;
+            if (c instanceof String s) {
+                s = s.trim();
+                if (s.equalsIgnoreCase("true"))  return true;
+                if (s.equalsIgnoreCase("false")) return false;
+                if (s.matches("\\d+")) return Integer.parseInt(s) != 0;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/service/EctRespostasAckService.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/service/EctRespostasAckService.java
@@ -1,0 +1,93 @@
+package mz.org.csaude.sespcet.api.service;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.*;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.uri.UriBuilder;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.scheduling.annotation.Async;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import mz.org.csaude.sespcet.api.crypto.CtCompactCrypto;
+import mz.org.csaude.sespcet.api.dto.EncryptedRequestDTO;
+import mz.org.csaude.sespcet.api.oauth.OAuthService;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.*;
+
+import static mz.org.csaude.sespcet.api.config.SettingKeys.*;
+
+@Slf4j
+@Singleton
+public class EctRespostasAckService {
+
+    @Inject @Client("/") HttpClient http;
+
+    private final SettingService settings;
+    private final OAuthService oauth;
+    private final CtCompactCrypto crypto;
+    private final JsonMapper json;
+
+    public EctRespostasAckService(SettingService settings,
+                                  OAuthService oauth,
+                                  CtCompactCrypto crypto,
+                                  JsonMapper json) {
+        this.settings = settings;
+        this.oauth = oauth;
+        this.crypto = crypto;
+        this.json = json;
+    }
+
+    /** Envia ACK assíncrono ao eCT com os pedidoIds consumidos. */
+    @Async
+    public void sendConsumedAckAsync(List<Long> pedidoIds) {
+        if (pedidoIds == null || pedidoIds.isEmpty()) {
+            log.info("ACK: nenhum pedidoId para reportar — nada a enviar.");
+            return;
+        }
+        try {
+            // 1) construir payload claro
+            Map<String, Object> ack = new LinkedHashMap<>();
+            ack.put("status", "CONSUMED");
+            ack.put("pedidoIds", new ArrayList<>(new LinkedHashSet<>(pedidoIds)));
+            ack.put("timestamp", Instant.now().toString());
+
+            String clearJson = new String(json.writeValueAsBytes(ack), StandardCharsets.UTF_8);
+
+            // 2) cifrar + assinar
+            String ctPubPem  = settings.get(CT_KEYS_CT_PUBLIC_PEM, null);
+            String apiPrvPem = settings.get(CT_KEYS_SESPCTAPI_PRIVATE_PEM, null);
+            if (ctPubPem == null || apiPrvPem == null) {
+                throw new IllegalStateException("ACK: chaves ausentes (CT_KEYS_CT_PUBLIC_PEM / CT_KEYS_SESPCTAPI_PRIVATE_PEM)");
+            }
+            EncryptedRequestDTO body = crypto.buildEncryptedEnvelope(clearJson, ctPubPem, apiPrvPem);
+
+            // 3) POST para /api/respostas/consumed no eCT
+            String consumedUrl = settings.get(CT_ENDPOINT_RESPOSTAS_CONSUMED, null);
+            if (consumedUrl == null || consumedUrl.isBlank()) {
+                String base = settings.get(CT_BASE_URL, "https://api.comitetarvmisau.co.mz");
+                consumedUrl = base.replaceAll("/+$","") + "/api/respostas/consumed";
+            }
+            URI uri = io.micronaut.http.uri.UriBuilder.of(consumedUrl).build();
+
+            HttpRequest<EncryptedRequestDTO> req = HttpRequest.POST(uri, body)
+                    .contentType(MediaType.APPLICATION_JSON_TYPE)
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .bearerAuth(oauth.getToken());
+
+            HttpResponse<String> resp = http.toBlocking().exchange(req, Argument.of(String.class));
+            int code = resp.getStatus().getCode();
+            if (code < 200 || code >= 300) {
+                throw new IllegalStateException("ACK falhou: status=" + resp.getStatus() +
+                        " body=" + resp.getBody().orElse(""));
+            }
+            log.info("ACK: enviado para {} pedido(s).", pedidoIds.size());
+        } catch (Exception e) {
+            log.warn("ACK: erro ao enviar confirmação de consumo: {}", e.toString());
+        }
+    }
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/service/EctSyncService.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/service/EctSyncService.java
@@ -1,0 +1,205 @@
+package mz.org.csaude.sespcet.api.service;
+
+import io.micronaut.json.JsonMapper;
+import jakarta.inject.Singleton;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import mz.org.csaude.sespcet.api.entity.Pedido;
+import mz.org.csaude.sespcet.api.repository.PedidoRepository;
+import mz.org.csaude.sespcet.api.util.DateUtils;
+import mz.org.csaude.sespcet.api.util.LifeCycleStatus;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static mz.org.csaude.sespcet.api.config.SettingKeys.*;
+
+@Slf4j
+@Singleton
+public class EctSyncService {
+
+    private final EctApiClient ect;
+    private final JsonMapper json;
+    private final PedidoRepository pedidoRepo;
+    private final SettingService settings;
+    private final EctWebhookService webhook;
+
+    public EctSyncService(EctApiClient ect,
+                          JsonMapper json,
+                          PedidoRepository pedidoRepo,
+                          SettingService settings,
+                          EctWebhookService webhook) {
+        this.ect = ect;
+        this.json = json;
+        this.pedidoRepo = pedidoRepo;
+        this.settings = settings;
+        this.webhook = webhook;
+    }
+
+    /**
+     * Pagina no eCT, insere Pedidos novos e, no fim,
+     * regista/actualiza o webhook só para os pedidos inseridos neste ciclo.
+     */
+    @Transactional
+    public void syncMissingPedidos(Integer limit, String startCursor, String direction) {
+        String cursor = (startCursor != null && !startCursor.isBlank()) ? startCursor : null;
+        String dir = (direction == null || direction.isBlank()) ? "next" : direction;
+        int page = 0;
+        int totalInserted = 0;
+
+        // Acumula os IDs criados neste ciclo para subscrição no webhook
+        final List<Long> newlyInsertedIds = new ArrayList<>();
+
+        while (true) {
+            page++;
+            try {
+                // usa o CLIENTE para paginar e já devolver items/next_cursor/has_more
+                EctApiClient.Page pageResp = ect.pagePedidos(limit != null ? limit : 20, cursor, dir, Collections.emptyMap());
+
+                List<Map<String, Object>> items = pageResp.items();
+                if (items == null || items.isEmpty()) {
+                    log.info("Sync: página {} vazia, terminando.", page);
+                    break;
+                }
+
+                int insertedThisPage = 0;
+                for (Map<String, Object> it : items) {
+                    Map<String, Object> dadosPedido = asMap(firstNonNull(it.get("dadosPedido"), it));
+                    if (dadosPedido == null) continue;
+
+                    Long pedidoId = numVal(
+                            path(dadosPedido, "metadados", "pedidoId"),
+                            dadosPedido.get("pedido_id"),
+                            dadosPedido.get("pedidoId")
+                    );
+                    if (pedidoId == null) continue;
+
+                    String facility = str(
+                            dadosPedido.get("codigo_unidade_sanitaria"),
+                            path(dadosPedido, "dadosUtente", "codigoUnidadeSanitaria"),
+                            dadosPedido.get("facilityCode")
+                    );
+                    if (facility == null) facility = "UNKNOWN";
+
+                    // evitar duplicados
+                    if (pedidoRepo.findByPedidoIdCt(pedidoId).isPresent()) continue;
+
+                    Pedido p = new Pedido();
+                    p.setPedidoIdCt(pedidoId);
+                    p.setFacilityCode(facility);
+                    p.setPayload(mapToJson(it));
+                    p.setStatus(Pedido.Status.NEW);
+                    p.setCreatedAt(DateUtils.getCurrentDate());
+                    p.setCreatedBy("system");
+                    p.setUuid(java.util.UUID.randomUUID().toString());
+                    p.setLifeCycleStatus(LifeCycleStatus.ACTIVE);
+                    pedidoRepo.save(p);
+
+                    newlyInsertedIds.add(pedidoId);
+                    insertedThisPage++;
+                }
+
+                totalInserted += insertedThisPage;
+                log.info("Sync: página {} → inseridos {}", page, insertedThisPage);
+
+                String next = str(pageResp.nextCursor());
+                Boolean hasMore = pageResp.hasMore();
+
+                if (Boolean.FALSE.equals(hasMore) || next == null || next.isBlank()) {
+                    log.info("Sync: fim (hasMore={}, next='{}', total inseridos = {})", hasMore, next, totalInserted);
+                    break;
+                }
+
+                settings.upsert(CT_SYNC_CURSOR, next, "STRING",
+                        "Último cursor de sync (eCT)", true, "system");
+                cursor = next;
+
+            } catch (Exception e) {
+                log.warn("Sync: falha na página {} (cursor={}) → {}", page, cursor, e.toString());
+                break;
+            }
+
+            if (page >= 200) { // guarda-chuva
+                log.warn("Sync: limite de páginas atingido ({}). Parando.", page);
+                break;
+            }
+        }
+
+        // Marca última execução
+        settings.upsert(CT_SYNC_LAST_RUN_ISO, Instant.now().toString(),
+                "STRING", "Última execução do sync eCT", true, "system");
+
+        // Se houve novos pedidos, regista/actualiza o webhook só para eles
+        if (!newlyInsertedIds.isEmpty()) {
+            try {
+                List<Long> distinctSorted = newlyInsertedIds.stream()
+                        .filter(Objects::nonNull)
+                        .distinct()
+                        .sorted()
+                        .collect(Collectors.toList());
+                webhook.registerForPedidoIds(distinctSorted);
+                log.info("Sync: webhook actualizado para {} novos pedido(s).", distinctSorted.size());
+            } catch (Exception e) {
+                log.warn("Sync: registo de webhook pós-sync falhou: {}", e.toString());
+            }
+        } else {
+            log.info("Sync: nenhum Pedido novo inserido — sem alterações ao webhook.");
+        }
+    }
+
+    /* ---------------- helpers ---------------- */
+
+    private String mapToJson(Object obj) throws Exception {
+        return new String(json.writeValueAsBytes(obj), java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object o) {
+        return (o instanceof Map) ? (Map<String, Object>) o : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> asListOfMaps(Object o) {
+        if (!(o instanceof List<?> list)) return null;
+        List<Map<String, Object>> out = new ArrayList<>(list.size());
+        for (Object el : list) if (el instanceof Map) out.add((Map<String, Object>) el);
+        return out;
+    }
+
+    private static Object path(Object m, String... keys) {
+        Object cur = m;
+        for (String k : keys) {
+            if (!(cur instanceof Map)) return null;
+            cur = ((Map<?, ?>) cur).get(k);
+        }
+        return cur;
+    }
+
+    private static Object firstNonNull(Object... xs) {
+        for (Object x : xs) if (x != null) return x;
+        return null;
+    }
+
+    private static String str(Object... candidates) {
+        for (Object c : candidates) {
+            if (c == null) continue;
+            String s = String.valueOf(c).trim();
+            if (!s.isEmpty() && !"null".equalsIgnoreCase(s)) return s;
+        }
+        return null;
+    }
+
+    /** Converte primeiro candidato numérico (Number ou String com dígitos) para Long. */
+    private static Long numVal(Object... candidates) {
+        for (Object c : candidates) {
+            if (c == null) continue;
+            if (c instanceof Number n) return n.longValue();
+            if (c instanceof String s) {
+                s = s.trim();
+                if (!s.isEmpty() && s.matches("\\d+")) return Long.parseLong(s);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/mz/org/csaude/sespcet/api/service/EctWebhookService.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/service/EctWebhookService.java
@@ -1,4 +1,3 @@
-// mz/org/csaude/sespcet/api/service/EctWebhookService.java
 package mz.org.csaude.sespcet.api.service;
 
 import io.micronaut.core.type.Argument;
@@ -8,9 +7,12 @@ import io.micronaut.http.client.annotation.Client;
 import io.micronaut.json.JsonMapper;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 import mz.org.csaude.sespcet.api.crypto.CtCompactCrypto;
 import mz.org.csaude.sespcet.api.dto.EncryptedRequestDTO;
+import mz.org.csaude.sespcet.api.entity.Pedido;
 import mz.org.csaude.sespcet.api.oauth.OAuthService;
+import mz.org.csaude.sespcet.api.repository.PedidoRepository;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -19,6 +21,7 @@ import java.util.*;
 
 import static mz.org.csaude.sespcet.api.config.SettingKeys.*;
 
+@Slf4j
 @Singleton
 public class EctWebhookService {
 
@@ -28,48 +31,86 @@ public class EctWebhookService {
     private final OAuthService oauth;
     private final CtCompactCrypto crypto;
     private final JsonMapper jsonMapper;
+    private final PedidoRepository pedidoRepo;
 
-    public EctWebhookService(SettingService settings, OAuthService oauth, CtCompactCrypto crypto, JsonMapper jsonMapper) {
+    public EctWebhookService(SettingService settings,
+                             OAuthService oauth,
+                             CtCompactCrypto crypto,
+                             JsonMapper jsonMapper,
+                             PedidoRepository pedidoRepo) {
         this.settings = settings;
         this.oauth = oauth;
         this.crypto = crypto;
         this.jsonMapper = jsonMapper;
+        this.pedidoRepo = pedidoRepo;
     }
 
-    /** Garante registo (idempotente). */
-    public void ensureRegistered() {
-        boolean already = settings.getBoolean(CT_WEBHOOK_REGISTERED, false);
-        if (!already) register();
-    }
-
-    /** Registo no eCT (POST /api/webhooks). */
-    public void register() {
+    /**
+     * Regista/atualiza a subscrição para a lista de pedidos fornecida.
+     * Envia o payload no formato consolidado:
+     * {
+     *   "url": "...",
+     *   "events": [...],
+     *   "pedidoIds": [...],
+     *   "secret": "...",
+     *   "timeout": 30,
+     *   "retryPolicy": { "maxAttempts": 3, "backoffSeconds": 5 }
+     * }
+     */
+    public void registerForPedidoIds(List<Long> pedidoIds) {
         try {
             String webhookUrl = settings.get(
                     CT_WEBHOOK_URL,
-                    "https://viewing-polish-diagnostic-supplier.trycloudflare.com/api/public/webhook/ect"
+                    "https://menu-killer-contemporary-assignments.trycloudflare.com/api/public/webhook/ect"
             );
+            String ctPubPem  = settings.get(CT_KEYS_CT_PUBLIC_PEM, null);
+            String apiPrvPem = settings.get(CT_KEYS_SESPCTAPI_PRIVATE_PEM, null);
+            if (ctPubPem == null || apiPrvPem == null) {
+                throw new IllegalStateException("Chaves ausentes (CT_KEYS_CT_PUBLIC_PEM / CT_KEYS_SESPCTAPI_PRIVATE_PEM)");
+            }
 
             URI uri = buildCtUri("/api/v1/webhooks");
 
-            // registar 1 evento por request
-            for (String event : eventsFromSettings()) {
+            // Configs adicionais
+            String secret = settings.get(CT_WEBHOOK_SECRET, "webhook-secret-key-123");
+            int timeoutSec = settings.getInt(CT_WEBHOOK_TIMEOUT_SECONDS, 30);
+            int retryMax = settings.getInt(CT_WEBHOOK_RETRY_MAX_ATTEMPTS, 3);
+            int retryBackoffSec = settings.getInt(CT_WEBHOOK_RETRY_BACKOFF_SECONDS, 5);
+
+            List<String> events = eventsFromSettings();
+
+            // Opcional: dividir em lotes para payloads grandes
+            final int CHUNK = settings.getInt(CT_WEBHOOK_PAGINATION_SIZE, 500);
+            for (int i = 0; i < pedidoIds.size(); i += CHUNK) {
+                List<Long> subList = pedidoIds.subList(i, Math.min(i + CHUNK, pedidoIds.size()));
+
                 Map<String, Object> clear = new LinkedHashMap<>();
                 clear.put("url", webhookUrl);
-                clear.put("event", event);
-                EncryptedRequestDTO body = crypto.buildEncryptedEnvelope(clear, settings.get(CT_KEYS_CT_PUBLIC_PEM, null), settings.get(CT_KEYS_SESPCTAPI_PRIVATE_PEM, null),  new String(jsonMapper.writeValueAsBytes(clear), StandardCharsets.UTF_8));
+                clear.put("events", events);
+                clear.put("pedidoIds", subList);
+                clear.put("secret", secret);
+                clear.put("timeout", timeoutSec);
+
+                Map<String, Object> retry = new LinkedHashMap<>();
+                retry.put("maxAttempts", retryMax);
+                retry.put("backoffSeconds", retryBackoffSec);
+                clear.put("retryPolicy", retry);
+
+                String clearJson = new String(jsonMapper.writeValueAsBytes(clear), StandardCharsets.UTF_8);
+                EncryptedRequestDTO body = crypto.buildEncryptedEnvelope(clearJson, ctPubPem, apiPrvPem);
 
                 HttpRequest<EncryptedRequestDTO> req = HttpRequest.POST(uri, body)
                         .contentType(MediaType.APPLICATION_JSON_TYPE)
                         .accept(MediaType.APPLICATION_JSON_TYPE)
-                        .bearerAuth(oauth.getToken()); // CtAuthFilter não interfere pq já existe Authorization
+                        .bearerAuth(oauth.getToken()); // CtAuthFilter ignorará porque já temos Authorization
 
                 HttpResponse<String> resp = http.toBlocking().exchange(req, Argument.of(String.class));
                 int code = resp.getStatus().getCode();
                 if (code < 200 || code >= 300) {
-                    throw new IllegalStateException("status=" + resp.getStatus() +
-                            " body=" + resp.getBody().orElse(""));
+                    throw new IllegalStateException("Falhou registo de webhook (chunk " + (i/CHUNK+1) + "): status="
+                            + resp.getStatus() + " body=" + resp.getBody().orElse(""));
                 }
+                log.info("Webhook: registado chunk {} com {} pedidoIds.", (i/CHUNK+1), subList.size());
             }
 
             settings.upsert(CT_WEBHOOK_REGISTERED, "true", "BOOLEAN", "Webhook registado no eCT", true, "system");
@@ -82,27 +123,35 @@ public class EctWebhookService {
         }
     }
 
-    public void unregister() {
+    /** (Opcional) Anular registos. Se o endpoint do eCT também aceitar pedidoIds/events em DELETE, adapta este método. */
+    public void unregisterForPedidoIds(List<Long> pedidoIds) {
         try {
             String webhookUrl = settings.get(CT_WEBHOOK_URL, "");
+            String ctPubPem  = settings.get(CT_KEYS_CT_PUBLIC_PEM, null);
+            String apiPrvPem = settings.get(CT_KEYS_SESPCTAPI_PRIVATE_PEM, null);
+            if (ctPubPem == null || apiPrvPem == null) {
+                throw new IllegalStateException("Chaves ausentes (CT_KEYS_CT_PUBLIC_PEM / CT_KEYS_SESPCTAPI_PRIVATE_PEM)");
+            }
+
             URI uri = buildCtUri("/api/v1/webhooks");
 
-            for (String event : eventsFromSettings()) {
-                Map<String, Object> clear = new LinkedHashMap<>();
-                clear.put("url", webhookUrl);
-                clear.put("event", event);
-                EncryptedRequestDTO body = crypto.buildEncryptedEnvelope(clear, settings.get(CT_KEYS_CT_PUBLIC_PEM, null), settings.get(CT_KEYS_SESPCTAPI_PRIVATE_PEM, null),  new String(jsonMapper.writeValueAsBytes(clear), StandardCharsets.UTF_8));
+            Map<String, Object> clear = new LinkedHashMap<>();
+            clear.put("url", webhookUrl);
+            clear.put("events", eventsFromSettings());
+            clear.put("pedidoIds", pedidoIds);
 
-                HttpRequest<EncryptedRequestDTO> req = HttpRequest.DELETE(uri, body)
-                        .contentType(MediaType.APPLICATION_JSON_TYPE)
-                        .accept(MediaType.APPLICATION_JSON_TYPE)
-                        .bearerAuth(oauth.getToken());
+            String clearJson = new String(jsonMapper.writeValueAsBytes(clear), StandardCharsets.UTF_8);
+            EncryptedRequestDTO body = crypto.buildEncryptedEnvelope(clearJson, ctPubPem, apiPrvPem);
 
-                HttpResponse<?> resp = http.toBlocking().exchange(req);
-                int code = resp.getStatus().getCode();
-                if (code < 200 || code >= 300) {
-                    throw new IllegalStateException("status=" + resp.getStatus());
-                }
+            HttpRequest<EncryptedRequestDTO> req = HttpRequest.DELETE(uri, body)
+                    .contentType(MediaType.APPLICATION_JSON_TYPE)
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .bearerAuth(oauth.getToken());
+
+            HttpResponse<?> resp = http.toBlocking().exchange(req);
+            int code = resp.getStatus().getCode();
+            if (code < 200 || code >= 300) {
+                throw new IllegalStateException("Falhou anulação de webhook: status=" + resp.getStatus());
             }
 
             settings.upsert(CT_WEBHOOK_REGISTERED, "false", "BOOLEAN", "Webhook registado no eCT", true, "system");
@@ -118,7 +167,11 @@ public class EctWebhookService {
     /* ------------ helpers ------------ */
 
     private List<String> eventsFromSettings() {
-        String csv = settings.get(CT_WEBHOOK_EVENTS, "PEDIDO_REPLIED,PEDIDO_UPDATED,RESPOSTA_UPDATED");
+        // Eventos suportados pelo eCT (podes ajustar a lista por configuração)
+        String csv = settings.get(CT_WEBHOOK_EVENTS, "PEDIDO_REPLIED,RESPOSTA_ADDED");
+        if (csv == null || csv.trim().isEmpty()) {
+            return List.of("PEDIDO_REPLIED,RESPOSTA_ADDED");
+        }
         return Arrays.asList(csv.split("\\s*,\\s*"));
     }
 

--- a/src/main/java/mz/org/csaude/sespcet/api/service/PedidoService.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/service/PedidoService.java
@@ -25,7 +25,7 @@ public class PedidoService {
         return pedidoRepository.findByStatus(Pedido.Status.NEW, pageable);
     }
 
-    public Pedido findByCtId(String pedidoIdCt, String facilityCode) {
+    public Pedido findByCtId(long pedidoIdCt, String facilityCode) {
         return pedidoRepository.findByPedidoIdCtAndFacilityCode(pedidoIdCt, facilityCode);
     }
 

--- a/src/main/java/mz/org/csaude/sespcet/api/service/RespostaService.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/service/RespostaService.java
@@ -25,7 +25,7 @@ public class RespostaService {
         return respostaRepository.findByStatusAndFacilityCode(Resposta.Status.NEW, facilityCode, pageable);
     }
 
-    public Resposta findByCtId(String respostaIdCt, String facilityCode) {
+    public Resposta findByCtId(Long respostaIdCt, String facilityCode) {
         return respostaRepository.findByRespostaIdCtAndFacilityCode(respostaIdCt, facilityCode);
     }
 

--- a/src/main/java/mz/org/csaude/sespcet/api/service/WebhookIngestService.java
+++ b/src/main/java/mz/org/csaude/sespcet/api/service/WebhookIngestService.java
@@ -1,0 +1,132 @@
+package mz.org.csaude.sespcet.api.service;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.json.JsonMapper;
+import jakarta.inject.Singleton;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import mz.org.csaude.sespcet.api.entity.Pedido;
+import mz.org.csaude.sespcet.api.entity.Resposta;
+import mz.org.csaude.sespcet.api.repository.PedidoRepository;
+import mz.org.csaude.sespcet.api.repository.RespostaRepository;
+import mz.org.csaude.sespcet.api.util.DateUtils;
+import mz.org.csaude.sespcet.api.util.LifeCycleStatus;
+
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+@Slf4j
+@Singleton
+@RequiredArgsConstructor
+public class WebhookIngestService {
+
+    private final JsonMapper json;
+    private final PedidoRepository pedidoRepo;
+    private final RespostaRepository respostaRepo;
+
+    /**
+     * Recebe JSON claro (desencriptado), persiste como Resposta (ou lança erro)
+     * e devolve a lista de pedidoIds consumidos para ACK posterior.
+     */
+    @Transactional
+    public List<Long> ingest(String clearJson) throws Exception {
+        Map<String, Object> root = json.readValue(
+                clearJson.getBytes(StandardCharsets.UTF_8),
+                Argument.mapOf(String.class, Object.class)
+        );
+
+        // Suporta payloads com "dadosResposta" OU achatados com "metadados.respostaId"
+        if (root.containsKey("dadosResposta")) {
+            Long pid = processResposta(asMap(root.get("dadosResposta")), clearJson);
+            return pid != null ? List.of(pid) : List.of();
+        }
+
+        Map<String, Object> meta = asMap(root.get("metadados"));
+        if (meta != null && meta.get("respostaId") != null) {
+            Long pid = processResposta(root, clearJson);
+            return pid != null ? List.of(pid) : List.of();
+        }
+
+        // (Opcional) Se o eCT puder enviar lote de respostas num array:
+        if (root.containsKey("respostas") && root.get("respostas") instanceof Collection<?> col) {
+            Set<Long> ids = new LinkedHashSet<>();
+            for (Object o : col) {
+                Map<String, Object> r = asMap(o);
+                if (r != null) {
+                    Long pid = processResposta(r.containsKey("dadosResposta") ? asMap(r.get("dadosResposta")) : r, clearJson);
+                    if (pid != null) ids.add(pid);
+                }
+            }
+            return new ArrayList<>(ids);
+        }
+
+        throw new IllegalArgumentException("Payload sem 'dadosResposta' ou 'metadados.respostaId'");
+    }
+
+    /**
+     * Persiste/actualiza a Resposta; devolve o pedidoId correspondente para ACK.
+     */
+    private Long processResposta(Map<String, Object> resposta, String payload) {
+        if (resposta == null) throw new IllegalStateException("Resposta nula");
+
+        Long respostaId = toLong(str(path(resposta, "metadados", "respostaId"),
+                path(resposta, "respostaId")));
+        Long pedidoId   = toLong(str(path(resposta, "metadados", "pedidoId"),
+                path(resposta, "pedidoId")));
+
+        if (respostaId == null) throw new IllegalStateException("Resposta sem respostaId");
+        if (pedidoId == null)   throw new IllegalStateException("Resposta sem pedidoId");
+
+        Resposta r = respostaRepo.findByRespostaIdCt(respostaId).orElseGet(Resposta::new);
+        r.setRespostaIdCt(respostaId);
+        r.setPedidoIdCt(pedidoId);
+        r.setPayload(payload);
+        r.setStatus(Resposta.Status.NEW);
+        r.setLifeCycleStatus(LifeCycleStatus.ACTIVE);
+        r.setCreatedAt(DateUtils.getCurrentDate());
+        r.setCreatedBy("system");
+
+        // herda facility do Pedido (se existir)
+        String facility = pedidoRepo.findByPedidoIdCt(pedidoId)
+                .map(Pedido::getFacilityCode)
+                .orElse("UNKNOWN");
+        r.setFacilityCode(facility);
+
+        respostaRepo.save(r);
+
+        log.info("Resposta {} (pedido {}) gravada/atualizada", respostaId, pedidoId);
+        return pedidoId;
+    }
+
+    /* ---------------- helpers ---------------- */
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object o) {
+        return (o instanceof Map) ? (Map<String, Object>) o : null;
+    }
+
+    private static Object path(Map<String, Object> m, String... keys) {
+        Object cur = m;
+        for (String k : keys) {
+            if (!(cur instanceof Map)) return null;
+            cur = ((Map<?, ?>) cur).get(k);
+        }
+        return cur;
+    }
+
+    private static String str(Object... candidates) {
+        for (Object c : candidates) {
+            if (c == null) continue;
+            String s = String.valueOf(c).trim();
+            if (!s.isEmpty() && !"null".equalsIgnoreCase(s)) return s;
+        }
+        return null;
+    }
+
+    private static Long toLong(String s) {
+        if (s == null) return null;
+        if (s.matches("\\d+")) return Long.parseLong(s);
+        return null;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,3 +55,8 @@ sespct:
   ct:
     bootstrap:
       enabled: true
+  sync:
+    enabled: true          # pode desligar sem recompilar
+    cron: "0 0/5 * * * ?"    # todos os dias às 02:05
+    zone: "Africa/Maputo"  # timezone local
+    limit: 20              # itens por página

--- a/src/main/resources/db/changelog/01-schema.xml
+++ b/src/main/resources/db/changelog/01-schema.xml
@@ -162,6 +162,101 @@
             </column>
         </createTable>
     </changeSet>
+    <changeSet id="2025-09-05-01-pedidos-pedido-id-to-bigint" author="voloide">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="pedidos"/>
+            <columnExists tableName="pedidos" columnName="pedido_id_ct"/>
+        </preConditions>
+        <modifyDataType tableName="pedidos"
+                        columnName="pedido_id_ct"
+                        newDataType="BIGINT"/>
+    </changeSet>
+
+    <!-- UNIQUE em pedidos.pedido_id_ct -->
+    <changeSet id="2025-09-05-02-pedidos-uk-pedido-id-ct" author="voloide">
+        <addUniqueConstraint tableName="pedidos"
+                             columnNames="pedido_id_ct"
+                             constraintName="uk_pedidos_pedido_id_ct"/>
+    </changeSet>
+
+    <!-- respostas.resposta_id_ct e respostas.pedido_id_ct -> BIGINT -->
+    <changeSet id="2025-09-05-03-respostas-ids-to-bigint" author="voloide">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="respostas"/>
+        </preConditions>
+
+        <modifyDataType tableName="respostas"
+                        columnName="resposta_id_ct"
+                        newDataType="BIGINT"/>
+
+        <modifyDataType tableName="respostas"
+                        columnName="pedido_id_ct"
+                        newDataType="BIGINT"/>
+    </changeSet>
+
+    <!-- UNIQUE em respostas.resposta_id_ct e índice por pedido_id_ct -->
+    <changeSet id="2025-09-05-04-respostas-constraints-index" author="voloide">
+        <addUniqueConstraint tableName="respostas"
+                             columnNames="resposta_id_ct"
+                             constraintName="uk_respostas_resposta_id_ct"/>
+
+        <createIndex tableName="respostas"
+                     indexName="idx_respostas_pedido_id_ct">
+            <column name="pedido_id_ct"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2025-09-05-uuid-01-add-col-pedidos" author="voloide">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="pedidos"/>
+        </preConditions>
+        <!-- VARCHAR(36) to hold UUID string -->
+        <addColumn tableName="pedidos">
+            <column name="uuid" type="VARCHAR(36)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="2025-09-05-uuid-03-constraints-pedidos" author="voloide">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="pedidos" columnName="uuid"/>
+        </preConditions>
+        <addNotNullConstraint tableName="pedidos"
+                              columnName="uuid"
+                              columnDataType="VARCHAR(36)"/>
+        <addUniqueConstraint tableName="pedidos"
+                             columnNames="uuid"
+                             constraintName="uk_pedidos_uuid"/>
+        <createIndex tableName="pedidos" indexName="idx_pedidos_uuid">
+            <column name="uuid"/>
+        </createIndex>
+    </changeSet>
+
+    <!-- ========= respostas.uuid ========= -->
+
+    <changeSet id="2025-09-05-uuid-04-add-col-respostas" author="voloide">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="respostas"/>
+        </preConditions>
+        <addColumn tableName="respostas">
+            <column name="uuid" type="VARCHAR(36)"/>
+        </addColumn>
+    </changeSet>
+
+
+    <changeSet id="2025-09-05-uuid-06-constraints-respostas" author="voloide">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="respostas" columnName="uuid"/>
+        </preConditions>
+        <addNotNullConstraint tableName="respostas"
+                              columnName="uuid"
+                              columnDataType="VARCHAR(36)"/>
+        <addUniqueConstraint tableName="respostas"
+                             columnNames="uuid"
+                             constraintName="uk_respostas_uuid"/>
+        <createIndex tableName="respostas" indexName="idx_respostas_uuid">
+            <column name="uuid"/>
+        </createIndex>
+    </changeSet>
 
     <changeSet id="create-client-table" author="jnmabjaia">
         <createTable tableName="clients">


### PR DESCRIPTION
Cria setting CT_ENDPOINT_RESPOSTAS_CONSUMED e grava default no bootstrap (<CT_BASE_URL>/api/respostas/consumed).

Implementa EctRespostasAckService para enviar ACK cifrado/assinado ao eCT com payload { status: "CONSUMED", pedidoIds: [...], timestamp: <ISO-8601> }.

Atualiza WebhookController para responder rápido (202) e orquestrar ingest + envio do ACK em background via @Async.

Ajusta WebhookIngestService para devolver List<Long> com pedidoIds consumidos; suporta payload achatado e batelado (respostas).

Remove registo de webhook do CtBootstrap; passa a apenas persistir configurações (webhook/sync: secret, timeout, retries, chunk size, cron, page limit).

Logs e validações melhorados.